### PR TITLE
MoonCloak goal for Bingo Mod

### DIFF
--- a/BingoMode.sln
+++ b/BingoMode.sln
@@ -11,8 +11,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D641543B-A480-4D21-834E-80C4D766E437}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D641543B-A480-4D21-834E-80C4D766E437}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D641543B-A480-4D21-834E-80C4D766E437}.Debug|Any CPU.ActiveCfg = Release|Any CPU
+		{D641543B-A480-4D21-834E-80C4D766E437}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{D641543B-A480-4D21-834E-80C4D766E437}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D641543B-A480-4D21-834E-80C4D766E437}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/BingoMode/BingoChallenges/BingoGreenNeuronChallenge.cs
+++ b/BingoMode/BingoChallenges/BingoGreenNeuronChallenge.cs
@@ -20,7 +20,11 @@ namespace BingoMode.BingoChallenges
 
         public override Phrase ConstructPhrase()
         {
-            return new Phrase([new Icon("GuidanceNeuron", 1f, new Color(0f, 1f, 0.3f)), new Icon("singlearrow", 1f, Color.white), new Icon(moon.Value ? "GuidanceMoon" : "nomscpebble", 1f, moon.Value ? new Color(1f, 0.8f, 0.3f) : new Color(0.44705883f, 0.9019608f, 0.76862746f))], []);
+            return new Phrase([
+                new Icon("GuidanceNeuron", 1f, new Color(0f, 1f, 0.3f)), 
+                new Icon("singlearrow", 1f, Color.white), 
+                new Icon(moon.Value ? "GuidanceMoon" : "nomscpebble", 1f, moon.Value ? new Color(1f, 0.8f, 0.3f) : new Color(0.44705883f, 0.9019608f, 0.76862746f))
+                ], []);
         }
 
         public override bool Duplicable(Challenge challenge)

--- a/BingoMode/BingoChallenges/BingoMoonCloak.cs
+++ b/BingoMode/BingoChallenges/BingoMoonCloak.cs
@@ -83,8 +83,7 @@ namespace BingoMode.BingoChallenges
 
         public override bool ValidForThisSlugcat(SlugcatStats.Name slugcat)
         {
-            //return (slugcat == SlugcatStats.Name.Red || slugcat == MoreSlugcatsEnums.SlugcatStatsName.Gourmand) || slugcat == SlugcatStats.Name.White || slugcat == SlugcatStats.Name.Yellow;
-            return slugcat != MoreSlugcatsEnums.SlugcatStatsName.Spear || slugcat != MoreSlugcatsEnums.SlugcatStatsName.Artificer;
+            return (slugcat == SlugcatStats.Name.Red || slugcat == MoreSlugcatsEnums.SlugcatStatsName.Gourmand) || slugcat == SlugcatStats.Name.White || slugcat == SlugcatStats.Name.Yellow;
         }
 
         public override string ToString()
@@ -120,7 +119,6 @@ namespace BingoMode.BingoChallenges
 
         public override void AddHooks()
         {
-            //IL.Player.GrabUpdate += Player_GrabUpdateCloak;
             On.Player.SlugcatGrab += Player_SlugcatGrabCloak;
             On.SLOracleBehaviorHasMark.MoonConversation.AddEvents += SLOracleBehavior_GrabCloak;
             if (!retreive.Value) IL.Room.Loaded += Room_LoadedMoonCloak;
@@ -129,7 +127,6 @@ namespace BingoMode.BingoChallenges
 
         public override void RemoveHooks()
         {
-            //IL.Player.GrabUpdate -= Player_GrabUpdateCloak;
             On.Player.SlugcatGrab -= Player_SlugcatGrabCloak;
             On.SLOracleBehaviorHasMark.MoonConversation.AddEvents -= SLOracleBehavior_GrabCloak;
             if (!retreive.Value) IL.Room.Loaded -= Room_LoadedMoonCloak;

--- a/BingoMode/BingoChallenges/BingoMoonCloak.cs
+++ b/BingoMode/BingoChallenges/BingoMoonCloak.cs
@@ -83,7 +83,7 @@ namespace BingoMode.BingoChallenges
 
         public override bool ValidForThisSlugcat(SlugcatStats.Name slugcat)
         {
-            return (slugcat == SlugcatStats.Name.Red || slugcat == MoreSlugcatsEnums.SlugcatStatsName.Gourmand) || slugcat == SlugcatStats.Name.White || slugcat == SlugcatStats.Name.Yellow;
+            return slugcat == SlugcatStats.Name.Red || slugcat == MoreSlugcatsEnums.SlugcatStatsName.Gourmand || slugcat == SlugcatStats.Name.White || slugcat == SlugcatStats.Name.Yellow;
         }
 
         public override string ToString()

--- a/BingoMode/BingoChallenges/BingoMoonCloak.cs
+++ b/BingoMode/BingoChallenges/BingoMoonCloak.cs
@@ -1,0 +1,141 @@
+﻿using BingoMode.BingoSteamworks;
+using Expedition;
+using MoreSlugcats;
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace BingoMode.BingoChallenges
+{
+    using static ChallengeHooks;
+    public class BingoMoonCloak : BingoChallenge
+    {
+        public SettingBox<bool> retreive;
+
+        public override void UpdateDescription()
+        {
+            description = ChallengeTools.IGT.Translate(retreive.Value ? "Obtain Moon's Cloak" : "Deliver the Cloak to Moon");
+            base.UpdateDescription();
+        }
+
+        public override Phrase ConstructPhrase()
+        {
+            if (retreive.Value)
+            {
+                return new Phrase([new Icon("Symbol_MoonCloak", 1f, new Color(0.8f, 0.8f, 0.8f))], []);
+            }
+            else
+            {
+                return new Phrase([
+                new Icon("Symbol_MoonCloak", 1f, new Color(0.8f, 0.8f, 0.8f)),
+                new Icon("singlearrow", 1f, Color.green),
+                new Icon("GuidanceMoon" , 1f, new Color(1f, 0.8f, 0.3f))
+                ], []);
+            }
+        }
+
+        public override bool Duplicable(Challenge challenge)
+        {
+            return challenge is not BingoMoonCloak c || (c.retreive.Value != retreive.Value);
+        }
+
+        public override string ChallengeName()
+        {
+            return ChallengeTools.IGT.Translate("Moon's Cloak");
+        }
+
+        public override Challenge Generate()
+        {
+            BingoMoonCloak ch = new BingoMoonCloak
+            {
+                retreive = new(UnityEngine.Random.value < 0.5f, "retreive", 0)
+            };
+
+            return ch;
+        }
+
+        public void Delivered()
+        {
+            if (!completed && !revealed && !TeamsCompleted[SteamTest.team] && !hidden && !retreive.Value)
+            {
+                CompleteChallenge();
+            }
+        }
+
+        public void Cloak()
+        {
+            if (!completed || !revealed || !TeamsCompleted[SteamTest.team] || !hidden || retreive.Value)
+            {
+                CompleteChallenge();
+            }
+        }
+
+        public override int Points()
+        {
+            return 20;
+        }
+
+        public override bool CombatRequired()
+        {
+            return false;
+        }
+
+        public override bool ValidForThisSlugcat(SlugcatStats.Name slugcat)
+        {
+            //return (slugcat == SlugcatStats.Name.Red || slugcat == MoreSlugcatsEnums.SlugcatStatsName.Gourmand) || slugcat == SlugcatStats.Name.White || slugcat == SlugcatStats.Name.Yellow;
+            return slugcat != MoreSlugcatsEnums.SlugcatStatsName.Spear || slugcat != MoreSlugcatsEnums.SlugcatStatsName.Artificer;
+        }
+
+        public override string ToString()
+        {
+            return string.Concat(new string[]
+            {
+                "BingoMoonCloak",
+                "~",
+                retreive.ToString(),
+                "><",
+                completed ? "1" : "0",
+                "><",
+                revealed ? "1" : "0",
+            });
+        }
+
+        public override void FromString(string args)
+        {
+            try
+            {
+                string[] array = Regex.Split(args, "><");
+                retreive = SettingBoxFromString(array[0]) as SettingBox<bool>;
+                completed = (array[1] == "1");
+                revealed = (array[2] == "1");
+                UpdateDescription();
+            }
+            catch (Exception ex)
+            {
+                ExpLog.Log("ERROR: BingoMoonCloak FromString() encountered an error: " + ex.Message);
+                throw ex;
+            }
+        }
+
+        public override void AddHooks()
+        {
+            //IL.Player.GrabUpdate += Player_GrabUpdateCloak;
+            On.Player.SlugcatGrab += Player_SlugcatGrabCloak;
+            On.SLOracleBehaviorHasMark.MoonConversation.AddEvents += SLOracleBehavior_GrabCloak;
+            if (!retreive.Value) IL.Room.Loaded += Room_LoadedMoonCloak;
+            //On.SaveState.ctor += SaveState_ctorCloak;
+        }
+
+        public override void RemoveHooks()
+        {
+            //IL.Player.GrabUpdate -= Player_GrabUpdateCloak;
+            On.Player.SlugcatGrab -= Player_SlugcatGrabCloak;
+            On.SLOracleBehaviorHasMark.MoonConversation.AddEvents -= SLOracleBehavior_GrabCloak;
+            if (!retreive.Value) IL.Room.Loaded -= Room_LoadedMoonCloak;
+            //On.SaveState.ctor -= SaveState_ctorCloak;
+        }
+
+        public override List<object> Settings() => [retreive];
+    }
+}

--- a/BingoMode/BingoChallenges/ChallengeHooks.cs
+++ b/BingoMode/BingoChallenges/ChallengeHooks.cs
@@ -1656,13 +1656,6 @@ namespace BingoMode.BingoChallenges
             Plugin.logger.LogInfo("Cloak after invoke!" + self.miscWorldSaveData.moonGivenRobe);
         }
 
-        //public static void MiscProgressionData_moonCloak(On.PlayerProgression.MiscProgressionData.orig_SetCloakTimelinePosition orig, PlayerProgression.MiscProgressionData self, SlugcatStats.Timeline slugcat)
-        //{
-        //    self.cloakTimelinePosition = null;
-        //    orig.Invoke(self, null);
-
-        //}
-
         public static void Room_LoadedMoonCloak(ILContext il)
         {
             ILCursor b = new(il);
@@ -1690,6 +1683,7 @@ namespace BingoMode.BingoChallenges
             }
             else Plugin.logger.LogError("Room_MoonCloak IL FAILURE " + il);
         }
+
         public static void SLOracleBehavior_GrabCloak(On.SLOracleBehaviorHasMark.MoonConversation.orig_AddEvents orig, SLOracleBehaviorHasMark.MoonConversation self)
         {
             orig.Invoke(self);

--- a/BingoMode/BingoChallenges/ChallengeHooks.cs
+++ b/BingoMode/BingoChallenges/ChallengeHooks.cs
@@ -1626,5 +1626,84 @@ namespace BingoMode.BingoChallenges
                 }
             }
         }
+
+        public static void Player_SlugcatGrabCloak(On.Player.orig_SlugcatGrab orig, Player self, PhysicalObject obj, int graspUsed)
+        {
+            orig.Invoke(self, obj, graspUsed);
+
+            if (obj.abstractPhysicalObject.type == MSCItemType.MoonCloak && self.room.abstractRoom.name.ToLowerInvariant() == "ms_farside")
+            {
+                for (int j = 0; j < ExpeditionData.challengeList.Count; j++)
+                {
+                    if (ExpeditionData.challengeList[j] is BingoMoonCloak c && c.retreive.Value)
+                    {
+                        c.Cloak();
+                    }
+                }
+            }
+        }
+
+        public static void SaveState_ctorCloak(On.SaveState.orig_ctor orig, SaveState self, SlugcatStats.Name saveStateNumber, PlayerProgression progression)
+        {
+            Plugin.logger.LogInfo("Original Cloak timeline position: " + progression.miscProgressionData.cloakTimelinePosition);
+            progression.miscProgressionData.cloakTimelinePosition = null;
+
+            orig.Invoke(self, saveStateNumber, progression);
+
+            self.miscWorldSaveData.moonGivenRobe = false;
+
+            Plugin.logger.LogInfo("Modified Cloak timeline position: " + progression.miscProgressionData.cloakTimelinePosition);
+            Plugin.logger.LogInfo("Cloak after invoke!" + self.miscWorldSaveData.moonGivenRobe);
+        }
+
+        //public static void MiscProgressionData_moonCloak(On.PlayerProgression.MiscProgressionData.orig_SetCloakTimelinePosition orig, PlayerProgression.MiscProgressionData self, SlugcatStats.Timeline slugcat)
+        //{
+        //    self.cloakTimelinePosition = null;
+        //    orig.Invoke(self, null);
+
+        //}
+
+        public static void Room_LoadedMoonCloak(ILContext il)
+        {
+            ILCursor b = new(il);
+            if (b.TryGotoNext(
+                x => x.MatchLdsfld("Expedition.ExpeditionData", "startingDen")
+                ) &&
+                b.TryGotoNext(MoveType.After,
+                x => x.MatchCallOrCallvirt<WorldCoordinate>(".ctor")
+                ))
+            {
+                b.Emit(OpCodes.Ldarg_0);
+                b.Emit(OpCodes.Ldloc, 72);
+                b.EmitDelegate<Action<Room, WorldCoordinate>>((room, pos) =>
+                {
+                    AbstractWorldEntity existingFucker = room.abstractRoom.entities.FirstOrDefault(x => x is AbstractPhysicalObject o && o.type == MSCItemType.MoonCloak);
+                    if (existingFucker != null)
+                    {
+                        room.abstractRoom.RemoveEntity(existingFucker);
+                    }
+
+                    AbstractPhysicalObject startItem = new AbstractConsumable(room.world, MSCItemType.MoonCloak, null, new WorldCoordinate(room.abstractRoom.index, room.shelterDoor.playerSpawnPos.x, room.shelterDoor.playerSpawnPos.y, 0), room.game.GetNewID(), -1, -1, null);
+                    room.abstractRoom.entities.Add(startItem);
+                    startItem.Realize();
+                });
+            }
+            else Plugin.logger.LogError("Room_MoonCloak IL FAILURE " + il);
+        }
+        public static void SLOracleBehavior_GrabCloak(On.SLOracleBehaviorHasMark.MoonConversation.orig_AddEvents orig, SLOracleBehaviorHasMark.MoonConversation self)
+        {
+            orig.Invoke(self);
+
+            if (self.describeItem == MoreSlugcatsEnums.MiscItemType.MoonCloak)
+            {
+                for (int j = 0; j < ExpeditionData.challengeList.Count; j++)
+                {
+                    if (ExpeditionData.challengeList[j] is BingoMoonCloak c && !c.retreive.Value)
+                    {
+                        c.Delivered();
+                    }
+                }
+            }
+        }
     }
 }

--- a/BingoMode/BingoChallenges/ChallengeHooks.cs
+++ b/BingoMode/BingoChallenges/ChallengeHooks.cs
@@ -1643,18 +1643,19 @@ namespace BingoMode.BingoChallenges
             }
         }
 
-        public static void SaveState_ctorCloak(On.SaveState.orig_ctor orig, SaveState self, SlugcatStats.Name saveStateNumber, PlayerProgression progression)
-        {
-            Plugin.logger.LogInfo("Original Cloak timeline position: " + progression.miscProgressionData.cloakTimelinePosition);
-            progression.miscProgressionData.cloakTimelinePosition = null;
+        //For debugging moonCloak and Timeline, make sure to uncomment the BingoMoonCloak hooks so its used
+        //public static void SaveState_ctorCloak(On.SaveState.orig_ctor orig, SaveState self, SlugcatStats.Name saveStateNumber, PlayerProgression progression)
+        //{
+        //    Plugin.logger.LogInfo("Original Cloak timeline position: " + progression.miscProgressionData.cloakTimelinePosition);
+        //    progression.miscProgressionData.cloakTimelinePosition = null;
 
-            orig.Invoke(self, saveStateNumber, progression);
+        //    orig.Invoke(self, saveStateNumber, progression);
 
-            self.miscWorldSaveData.moonGivenRobe = false;
+        //    self.miscWorldSaveData.moonGivenRobe = false;
 
-            Plugin.logger.LogInfo("Modified Cloak timeline position: " + progression.miscProgressionData.cloakTimelinePosition);
-            Plugin.logger.LogInfo("Cloak after invoke!" + self.miscWorldSaveData.moonGivenRobe);
-        }
+        //    Plugin.logger.LogInfo("Modified Cloak timeline position: " + progression.miscProgressionData.cloakTimelinePosition);
+        //    Plugin.logger.LogInfo("Cloak after invoke!" + self.miscWorldSaveData.moonGivenRobe);
+        //}
 
         public static void Room_LoadedMoonCloak(ILContext il)
         {
@@ -1667,7 +1668,7 @@ namespace BingoMode.BingoChallenges
                 ))
             {
                 b.Emit(OpCodes.Ldarg_0);
-                b.Emit(OpCodes.Ldloc, 72);
+                b.Emit(OpCodes.Ldloc, 140);
                 b.EmitDelegate<Action<Room, WorldCoordinate>>((room, pos) =>
                 {
                     AbstractWorldEntity existingFucker = room.abstractRoom.entities.FirstOrDefault(x => x is AbstractPhysicalObject o && o.type == MSCItemType.MoonCloak);

--- a/BingoMode/BingoMode.csproj
+++ b/BingoMode/BingoMode.csproj
@@ -172,6 +172,6 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetPath)" "E:\Program Files (x86)\Steam\steamapps\common\Rain World\RainWorld_Data\StreamingAssets\mods\bingomode\v1.9.15b\plugins\$(TargetName).dll"</PostBuildEvent>
+    <PostBuildEvent>copy /Y "$(TargetPath)" "E:\Program Files (x86)\Steam\steamapps\common\Rain World\RainWorld_Data\StreamingAssets\mods\bingomode\newest\plugins\$(TargetName).dll"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/BingoMode/BingoMode.csproj
+++ b/BingoMode/BingoMode.csproj
@@ -96,6 +96,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BingoBoard.cs" />
+    <Compile Include="BingoChallenges\BingoMoonCloak.cs" />
     <Compile Include="BingoMenu\BingoCredits.cs" />
     <Compile Include="BingoHUD\BingoHUDCheatButton.cs" />
     <Compile Include="BingoMenu\BingoButton.cs" />
@@ -171,6 +172,6 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetPath)" "C:\Program Files (x86)\Steam\steamapps\common\Rain World\RainWorld_Data\StreamingAssets\mods\bingomode\plugins\$(TargetName).dll"</PostBuildEvent>
+    <PostBuildEvent>copy /Y "$(TargetPath)" "E:\Program Files (x86)\Steam\steamapps\common\Rain World\RainWorld_Data\StreamingAssets\mods\bingomode\v1.9.15b\plugins\$(TargetName).dll"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This adds the Bingo Goal of bringing Moon's Cloak and giving it to her, or needing to go get Moon's Cloak. Or both!
This is compatible with Hunter's Green Neuron goal of restarting Moon, but the Give Cloak goal will not give credit until Moon is able to actually grab it.

This goal is only valid for Hunter, Gourmand, Survivor, and Monk.