### PR TITLE
Bingo page refactor (#13)

### DIFF
--- a/BingoMode/BingoBoard.cs
+++ b/BingoMode/BingoBoard.cs
@@ -43,27 +43,22 @@ namespace BingoMode
             BingoData.FillPossibleTokens(ExpeditionData.slugcatPlayer);
             ExpeditionData.ClearActiveChallengeList();
             if (changeSize)
-            { 
                 ghostGrid = challengeGrid;
-            }
+
             challengeGrid = new Challenge[size, size];
-            for (int i = 0; i < size; i++)
+            for (int j = 0; j < size; j++)
             {
-                for (int j = 0; j < size; j++)
+                for (int i = 0; i < size; i++)
                 {
-                    if (changeSize)
+                    if (changeSize && !(i + 1 > ghostGrid.GetLength(0) || j + 1 > ghostGrid.GetLength(1)) && ghostGrid[i, j] != null)
                     {
-                        if (!(i + 1 > ghostGrid.GetLength(0) || j + 1 > ghostGrid.GetLength(1)) && ghostGrid[i, j] != null)
-                        {
-                            challengeGrid[i, j] = ghostGrid[i, j];
-                            if (!ExpeditionData.challengeList.Contains(challengeGrid[i, j])) ExpeditionData.challengeList.Add(challengeGrid[i, j]);
-                            continue;
-                        }
-                    }
-                    if (challengeGrid[i, j] != null)
-                    {
+                        challengeGrid[i, j] = ghostGrid[i, j];
+                        if (!ExpeditionData.challengeList.Contains(challengeGrid[i, j]))
+                            ExpeditionData.challengeList.Add(challengeGrid[i, j]);
                         continue;
                     }
+                    if (challengeGrid[i, j] != null)
+                        continue;
                     challengeGrid[i, j] = RandomBingoChallenge(x: i, y: j);
                 }
             }
@@ -76,36 +71,28 @@ namespace BingoMode
             int rows = challengeGrid.GetLength(0);
             int cols = challengeGrid.GetLength(1);
 
-            List<Challenge> flatList = new List<Challenge>();
-            for (int i = 0; i < rows; i++)
-            {
-                for (int j = 0; j < cols; j++)
-                {
+            List<Challenge> flatList = [];
+            for (int j = 0; j < cols; j++)
+                for (int i = 0; i < rows; i++)
                     flatList.Add(challengeGrid[i, j]);
-                }
-            }
 
             for (int i = 0; i < flatList.Count; i++)
             {
                 int randomIndex = UnityEngine.Random.Range(i, flatList.Count);
-                Challenge temp = flatList[i];
-                flatList[i] = flatList[randomIndex];
-                flatList[randomIndex] = temp;
+                (flatList[randomIndex], flatList[i]) = (flatList[i], flatList[randomIndex]);
             }
 
             ExpeditionData.ClearActiveChallengeList();
             int index = 0;
-            for (int i = 0; i < rows; i++)
+            for (int j = 0; j < cols; j++)
             {
-                for (int j = 0; j < cols; j++)
+                for (int i = 0; i < rows; i++)
                 {
                     Challenge shuffledChallenge = flatList[index++];
                     challengeGrid[i, j] = shuffledChallenge;
 
                     if (!ExpeditionData.challengeList.Contains(shuffledChallenge))
-                    {
                         ExpeditionData.challengeList.Add(shuffledChallenge);
-                    }
                 }
             }
 
@@ -139,15 +126,13 @@ namespace BingoMode
                 ExpeditionData.ClearActiveChallengeList();
                 int rows = challengeGrid.GetLength(0);
                 int cols = challengeGrid.GetLength(1);
-                for (int i = 0; i < rows; i++)
+                for (int j = 0; j < cols; j++)
                 {
-                    for (int j = 0; j < cols; j++)
+                    for (int i = 0; i < rows; i++)
                     {
                         Challenge c = challengeGrid[i, j];
                         if (c != null && !ExpeditionData.challengeList.Contains(c))
-                        {
                             ExpeditionData.challengeList.Add(c);
-                        }
                     }
                 }
 
@@ -164,9 +149,8 @@ namespace BingoMode
             switch1 = null;
             switch2 = null;
             foreach (Challenge c in ExpeditionData.challengeList)
-            {
                 c.UpdateDescription();
-            }
+
             ExpeditionMenu self = BingoData.globalMenu;
             if (self != null && BingoHooks.bingoPage.TryGetValue(self, out var page) && page.grid != null)
             {
@@ -199,48 +183,40 @@ namespace BingoMode
                 {
                     var ch = challengeGrid[i, j];
                     if ((ch as BingoChallenge).TeamsFailed[t])
-                    {
                         line = false;
-                    }
                     if (line && lockout && (ch as BingoChallenge).TeamsCompleted.Any(x => x == true) && !(ch as BingoChallenge).TeamsCompleted[t])
-                    {
                         line = false;
-                    }
-                    if (line) currentWinLine.Add(new IntVector2(i, j));
+                    if (line)
+                        currentWinLine.Add(new IntVector2(i, j));
                 }
                 won = line;
                 if (won)
-                {
                     break;
-                }
-                else currentWinLine.Clear();
+                else
+                    currentWinLine.Clear();
             }
 
             // Horizontal lines
             if (!won)
             {
-                for (int i = 0; i < size; i++)
+                for (int j = 0; j < size; j++)
                 {
                     bool line = true;
-                    for (int j = 0; j < size; j++)
+                    for (int i = 0; i < size; i++)
                     {
-                        var ch = challengeGrid[j, i];
+                        var ch = challengeGrid[i, j];
                         if ((ch as BingoChallenge).TeamsFailed[t])
-                        {
                             line = false;
-                        }
                         if (line && lockout && (ch as BingoChallenge).TeamsCompleted.Any(x => x == true) && !(ch as BingoChallenge).TeamsCompleted[t])
-                        {
                             line = false;
-                        }
-                        if (line) currentWinLine.Add(new IntVector2(j, i));
+                        if (line)
+                            currentWinLine.Add(new IntVector2(i, j));
                     }
                     won = line;
                     if (won)
-                    {
                         break;
-                    }
-                    else currentWinLine.Clear();
+                    else
+                        currentWinLine.Clear();
                 }
             }
 
@@ -252,20 +228,15 @@ namespace BingoMode
                 {
                     var ch = challengeGrid[i, i];
                     if ((ch as BingoChallenge).TeamsFailed[t])
-                    {
                         line = false;
-                    }
                     if (line && lockout && (ch as BingoChallenge).TeamsCompleted.Any(x => x == true) && !(ch as BingoChallenge).TeamsCompleted[t])
-                    {
                         line = false;
-                    }
-                    if (line) currentWinLine.Add(new IntVector2(i, i));
+                    if (line)
+                        currentWinLine.Add(new IntVector2(i, i));
                 }
                 won = line;
-                if (won)
-                {
-                }
-                else currentWinLine.Clear();
+                if (!won)
+                    currentWinLine.Clear();
             }
 
             // Diagonal line 2
@@ -276,20 +247,15 @@ namespace BingoMode
                 {
                     var ch = challengeGrid[size - 1 - i, i];
                     if ((ch as BingoChallenge).TeamsFailed[t])
-                    {
                         line = false;
-                    }
                     if (line && lockout && (ch as BingoChallenge).TeamsCompleted.Any(x => x == true) && !(ch as BingoChallenge).TeamsCompleted[t])
-                    {
                         line = false;
-                    }
-                    if (line) currentWinLine.Add(new IntVector2(size - 1 - i, i));
+                    if (line)
+                        currentWinLine.Add(new IntVector2(size - 1 - i, i));
                 }
                 won = line;
-                if (won)
-                {
-                }
-                else currentWinLine.Clear();
+                if (!won)
+                    currentWinLine.Clear();
             }
 
             currentWinLine = [];
@@ -310,34 +276,33 @@ namespace BingoMode
                 {
                     var ch = challengeGrid[i, j];
                     line &= (ch as BingoChallenge).TeamsCompleted[t];
-                    if (line) currentWinLine.Add(new IntVector2(i, j));
+                    if (line)
+                        currentWinLine.Add(new IntVector2(i, j));
                 }
                 won = line;
                 if (won)
-                {
-                                        break;
-                }
-                else currentWinLine.Clear();
+                    break;
+                else
+                    currentWinLine.Clear();
             }
 
             // Horizontal lines
             if (!won)
             {
-                for (int i = 0; i < size; i++)
+                for (int j = 0; j < size; j++)
                 {
                     bool line = true;
-                    for (int j = 0; j < size; j++)
+                    for (int i = 0; i < size; i++)
                     {
-                        var ch = challengeGrid[j, i];
+                        var ch = challengeGrid[i, j];
                         line &= (ch as BingoChallenge).TeamsCompleted[t];
-                        if (line) currentWinLine.Add(new IntVector2(j, i));
+                        if (line) currentWinLine.Add(new IntVector2(i, j));
                     }
                     won = line;
                     if (won)
-                    {
-                                                break;
-                    }
-                    else currentWinLine.Clear();
+                        break;
+                    else
+                        currentWinLine.Clear();
                 }
             }
 
@@ -352,10 +317,8 @@ namespace BingoMode
                     if (line) currentWinLine.Add(new IntVector2(i, i));
                 }
                 won = line;
-                if (won)
-                {
-                                    }
-                else currentWinLine.Clear();
+                if (!won)
+                    currentWinLine.Clear();
             }
 
             // Diagonal line 2
@@ -369,19 +332,13 @@ namespace BingoMode
                     if (line) currentWinLine.Add(new IntVector2(size - 1 - i, i));
                 }
                 won = line;
-                if (won)
-                {
-                                    }
-                else currentWinLine.Clear();
+                if (!won)
+                    currentWinLine.Clear();
             }
 
             if (overrideArray != null)
-            {
                 foreach (var coord in currentWinLine)
-                {
                     overrideArray.Add(coord);
-                }
-            }
             currentWinLine = [];
             return won;
         }
@@ -418,13 +375,13 @@ namespace BingoMode
             }
 
             // Horizontal lines
-            for (int i = 0; i < size; i++)
+            for (int j = 0; j < size; j++)
             {
                 int tempSquaresH = 0;
                 bool fuckThisShitImOut = false;
-                for (int j = 0; j < size; j++)
+                for (int i = 0; i < size; i++)
                 {
-                    var ch = challengeGrid[j, i] as BingoChallenge;
+                    var ch = challengeGrid[i, j] as BingoChallenge;
                     if (ch.TeamsCompleted[t]) tempSquaresH++;
                     else if (lockout)
                     {
@@ -489,7 +446,13 @@ namespace BingoMode
         public Challenge RandomBingoChallenge(Challenge type = null, bool ignore = false, int x = 1, int y = -1)
         {
             if (BingoRandomizationProfile.IsLoaded)
-                return BingoRandomizationProfile.GetChallenge();
+                try
+                {
+                    return BingoRandomizationProfile.GetChallenge();
+                } catch (Exception)
+                {
+                    Plugin.logger.LogMessage("Error getting challenge from randomizer, resorting to default generation.");
+                }
 
             if (BingoData.availableBingoChallenges == null)
             {
@@ -533,8 +496,10 @@ namespace BingoMode
                 list.Remove(ch);
                 goto resette;
             }
-            if (ch == null) ch = (Activator.CreateInstance(BingoData.availableBingoChallenges.Find((Challenge c) => c.GetType().Name == "BingoKillChallenge").GetType()) as Challenge).Generate();
-            if (!ExpeditionData.challengeList.Contains(ch) && !ignore) ExpeditionData.challengeList.Add(ch);
+            if (ch == null)
+                ch = (Activator.CreateInstance(BingoData.availableBingoChallenges.Find((Challenge c) => c.GetType().Name == "BingoKillChallenge").GetType()) as Challenge).Generate();
+            if (!ExpeditionData.challengeList.Contains(ch) && !ignore)
+                ExpeditionData.challengeList.Add(ch);
             return ch;
         }
 
@@ -543,19 +508,22 @@ namespace BingoMode
             // Horizontal check
             for (int i = 0; i < size; i++)
             {
-                if (challengeGrid[i, y] != null && (challengeGrid[i, y] as BingoChallenge).ReverseChallenge()) return true;
+                if (challengeGrid[i, y] != null && (challengeGrid[i, y] as BingoChallenge).ReverseChallenge())
+                    return true;
             }
             // Vertical check
             for (int i = 0; i < size; i++)
             {
-                if (challengeGrid[x, i] != null && (challengeGrid[x, i] as BingoChallenge).ReverseChallenge()) return true;
+                if (challengeGrid[x, i] != null && (challengeGrid[x, i] as BingoChallenge).ReverseChallenge())
+                    return true;
             }
             // Diagonal 1 check
             if (x == y)
             {
                 for (int i = 0; i < size; i++)
                 {
-                    if (challengeGrid[i, i] != null && (challengeGrid[i, i] as BingoChallenge).ReverseChallenge()) return true;
+                    if (challengeGrid[i, i] != null && (challengeGrid[i, i] as BingoChallenge).ReverseChallenge())
+                        return true;
                 }
             }
             // Diagonal 2 check
@@ -563,7 +531,8 @@ namespace BingoMode
             {
                 for (int i = 0; i < size; i++)
                 {
-                    if (challengeGrid[size - 1 - i, i] != null && (challengeGrid[size - 1 - i, i] as BingoChallenge).ReverseChallenge()) return true;
+                    if (challengeGrid[size - 1 - i, i] != null && (challengeGrid[size - 1 - i, i] as BingoChallenge).ReverseChallenge())
+                        return true;
                 }
             }
 
@@ -579,21 +548,9 @@ namespace BingoMode
                  
                 challengeGrid = new Challenge[size, size];
                 int next = 0;
-                for (int i = 0; i < size; i++)
-                {
-                    for (int j = 0; j < size; j++)
-                    {
-                        //if (recreateList.Count < next + 1)
-                        //{
-                        //    challengeGrid[i, j] = RandomBingoChallenge();
-                        //}
-                        //else 
-                        challengeGrid[i, j] = recreateList[next];
-                        //(challengeGrid[i, j] as IBingoChallenge).Index = next;
-                         
-                        next++;
-                    }
-                }
+                for (int j = 0; j < size; j++)
+                    for (int i = 0; i < size; i++)
+                        challengeGrid[i, j] = recreateList[next++];
                 
                 SteamTest.UpdateOnlineBingo();
                 UpdateChallenges();
@@ -632,7 +589,13 @@ namespace BingoMode
             
             if (slug.ToLowerInvariant() != ExpeditionData.slugcatPlayer.value.ToLowerInvariant())
             {
-                if (BingoData.globalMenu != null) BingoData.globalMenu.manager.ShowDialog(new InfoDialog(BingoData.globalMenu.manager, $"Slugcat mismatch!\n\nSelected slugcat: {ExpeditionData.slugcatPlayer.value}\nProvided Slugcat: {slug}\n\nPlease paste a board from the same slugcat that's currently selected."));
+                if (BingoData.globalMenu != null)
+                    BingoData.globalMenu.manager.ShowDialog(new InfoDialog(
+                            BingoData.globalMenu.manager,
+                            $"Slugcat mismatch!\n\n" +
+                            $"Selected slugcat: {ExpeditionData.slugcatPlayer.value}\n" +
+                            $"Provided Slugcat: {slug}\n\n" +
+                            $"Please paste a board from the same slugcat that's currently selected."));
                 return;
             }
 
@@ -644,9 +607,9 @@ namespace BingoMode
                 size = Mathf.RoundToInt(Mathf.Sqrt(challenges.Length));
                 int next = 0;
                 challengeGrid = new Challenge[size, size];
-                for (int i = 0; i < size; i++)
+                for (int j = 0; j < size; j++)
                 {
-                    for (int j = 0; j < size; j++)
+                    for (int i = 0; i < size; i++)
                     {
                         try
                         {
@@ -685,35 +648,35 @@ namespace BingoMode
 
         public Challenge GetChallenge(int x, int y)
         {
-            if (x < challengeGrid.GetLength(0) && y < challengeGrid.GetLength(1)) return challengeGrid[x, y];
+            if (x < challengeGrid.GetLength(0) && y < challengeGrid.GetLength(1))
+                return challengeGrid[x, y];
             return null;
         }
 
         public string GetBingoState()
         {
             string state = "";
-            for (int i = 0; i < challengeGrid.GetLength(0); i++)
-            {
-                for (int j = 0; j < challengeGrid.GetLength(1); j++)
-                {
+            for (int j = 0; j < challengeGrid.GetLength(1); j++)
+                for (int i = 0; i < challengeGrid.GetLength(0); i++)
                     state += "<>" + (challengeGrid[i, j] as BingoChallenge).TeamsToString();
-                }
-            }
             if (state != "") state = state.Substring(2);
             return state;
         }
 
         public void InterpretBingoState(string state)
         {
-            if (challengeGrid == null) { Plugin.logger.LogError("CHALLENGE GRID IS NULL!! Returning"); return; }
+            if (challengeGrid == null)
+            {
+                Plugin.logger.LogError("CHALLENGE GRID IS NULL!! Returning");
+                return;
+            }
 
             string[] challenges = Regex.Split(state, "<>");
-            
 
             int next = 0;
-            for (int i = 0; i < size; i++)
+            for (int j = 0; j < size; j++)
             {
-                for (int j = 0; j < size; j++)
+                for (int i = 0; i < size; i++)
                 {
                     if (challengeGrid[i, j] == null)
                     {
@@ -722,9 +685,8 @@ namespace BingoMode
                     }
                     BingoChallenge ch = challengeGrid[i, j] as BingoChallenge;
                     string currentTeamsString = ch.TeamsToString();
-                    string newTeamsString = challenges[next];
+                    string newTeamsString = challenges[next++];
 
-                    //
                     // All the switch statements to make it 100% clear, obviously can be shortened down
                     if (currentTeamsString != newTeamsString)
                     {
@@ -835,7 +797,6 @@ namespace BingoMode
                             }
                         }
                     }
-                    next++;
                 }
             }
         }

--- a/BingoMode/BingoHUD/BingoHUDMain.cs
+++ b/BingoMode/BingoHUD/BingoHUDMain.cs
@@ -189,7 +189,7 @@ namespace BingoMode.BingoHUD
                             }
                         }
                     }
-                    bingoCompleteInfo.text = endGameInfo.subTitle.Replace("<team_name>", BingoPage.TeamName(endGameInfo.teams[0])) + "\n" + endGameInfo.evenSubtlerTitle;
+                    bingoCompleteInfo.text = endGameInfo.subTitle.Replace("<team_name>", BingoPage.TeamName[endGameInfo.teams[0]]) + "\n" + endGameInfo.evenSubtlerTitle;
                     bingoCompleteInfo.color = BingoPage.TEAM_COLOR[endGameInfo.teams[0]];
                     break;
 
@@ -201,7 +201,7 @@ namespace BingoMode.BingoHUD
                         completeQueue.Add(grid[g.x, g.y]);
                         grid[g.x, g.y].teamResponsible = endGameInfo.teams[0];
                     }
-                    bingoCompleteInfo.text = endGameInfo.subTitle.Replace("<team_name>", BingoPage.TeamName(endGameInfo.teams[0])) + "\n" + endGameInfo.evenSubtlerTitle;
+                    bingoCompleteInfo.text = endGameInfo.subTitle.Replace("<team_name>", BingoPage.TeamName[endGameInfo.teams[0]]) + "\n" + endGameInfo.evenSubtlerTitle;
                     bingoCompleteInfo.color = BingoPage.TEAM_COLOR[endGameInfo.teams[0]];
                     break;
                 case BingoCompleteReason.Tie:
@@ -468,13 +468,10 @@ namespace BingoMode.BingoHUD
         public int CompletedChallengesForTeam(int team)
         {
             int all = 0;
-            for (int x = 0; x < grid.GetLength(0); x++)
-            {
-                for (int y = 0; y < grid.GetLength(0); y++)
-                {
-                    if ((BingoHooks.GlobalBoard.challengeGrid[x, y] as BingoChallenge).TeamsCompleted[team]) all++;
-                }
-            }
+            for (int j = 0; j < grid.GetLength(1); j++)
+                for (int i = 0; i < grid.GetLength(0); i++)
+                    if ((BingoHooks.GlobalBoard.challengeGrid[i, j] as BingoChallenge).TeamsCompleted[team])
+                        all++;
             
             return all;
         }
@@ -523,7 +520,7 @@ namespace BingoMode.BingoHUD
                 foreach (var kvp in completedForTeam)
                 {
                     
-                    addText += "\n" + BingoPage.TeamName(kvp.Key) + " - " + kvp.Value;
+                    addText += "\n" + BingoPage.TeamName[kvp.Key] + " - " + kvp.Value;
                 }
             }
             else
@@ -822,9 +819,9 @@ namespace BingoMode.BingoHUD
         {
             grid = new BingoInfo[board.size, board.size];
 
-            for (int i = 0; i < grid.GetLength(0); i++)
+            for (int j = 0; j < grid.GetLength(1); j++)
             {
-                for (int j = 0; j < grid.GetLength(1); j++)
+                for (int i = 0; i < grid.GetLength(0); i++)
                 {
                     float size = (BingoData.SpectatorMode ? 475f : 420f) / board.size;
                     float topLeft = -size * board.size / 2f;
@@ -1513,7 +1510,7 @@ namespace BingoMode.BingoHUD
                     infoLabel.text += "\nCompleted by: ";
                     for (int i = 0; i < (challenge as BingoChallenge).TeamsCompleted.Length; i++)
                     {
-                        if ((challenge as BingoChallenge).TeamsCompleted[i]) infoLabel.text += BingoPage.TeamName(i) + ", ";
+                        if ((challenge as BingoChallenge).TeamsCompleted[i]) infoLabel.text += BingoPage.TeamName[i] + ", ";
                     }
                     infoLabel.text = infoLabel.text.Substring(0, infoLabel.text.Length - 2); // Trim the last ", "
                 }
@@ -1522,7 +1519,7 @@ namespace BingoMode.BingoHUD
                     infoLabel.text += "\nFailed by: ";
                     for (int i = 0; i < (challenge as BingoChallenge).TeamsFailed.Length; i++)
                     {
-                        if ((challenge as BingoChallenge).TeamsFailed[i]) infoLabel.text += BingoPage.TeamName(i) + ", ";
+                        if ((challenge as BingoChallenge).TeamsFailed[i]) infoLabel.text += BingoPage.TeamName[i] + ", ";
                     }
                     infoLabel.text = infoLabel.text.Substring(0, infoLabel.text.Length - 2); // Trim the last ", "
                 }

--- a/BingoMode/BingoHooks.cs
+++ b/BingoMode/BingoHooks.cs
@@ -843,7 +843,7 @@ namespace BingoMode
         {
             orig.Invoke(self);
 
-            if (bingoPage.TryGetValue(self.owner.menu as ExpeditionMenu, out var pag) && pag.unlocksButton.greyedOut)
+            if (bingoPage.TryGetValue(self.owner.menu as ExpeditionMenu, out var pag))
             {
                 self.pageTitle.x = pag.pos.x + 685f;
                 self.pageTitle.y = pag.pos.y + 680f;
@@ -857,10 +857,7 @@ namespace BingoMode
             if (message == "CLOSE")
             {
                 if (bingoPage.TryGetValue(self.owner.menu as ExpeditionMenu, out var pag))
-                {
-                    pag.unlocksButton.greyedOut = false;
-                    pag.unlocksButton.Reset();
-                }
+                    pag.UnlocksDialogClose();
 
                 if (!BingoData.MultiplayerGame || SteamMatchmaking.GetLobbyOwner(SteamTest.CurrentLobby) != SteamTest.selfIdentity.GetSteamID()) return;
                 if (BingoData.globalSettings.perks == LobbySettings.AllowUnlocks.Inherited)
@@ -1070,13 +1067,12 @@ namespace BingoMode
             GlobalBoard.size = size;
             GlobalBoard.challengeGrid = new Challenge[size, size];
             int chIndex = 0;
-            for (int i = 0; i < size; i++)
+            for (int j = 0; j < size; j++)
             {
-                for (int j = 0; j < size; j++)
+                for (int i = 0; i < size; i++)
                 {
-                    GlobalBoard.challengeGrid[i, j] = ExpeditionData.challengeList[chIndex];
+                    GlobalBoard.challengeGrid[i, j] = ExpeditionData.challengeList[chIndex++];
                     //ExpeditionData.challengeList.Add(GlobalBoard.challengeGrid[i, j]);
-                    chIndex++;
                 }
             }
             SteamTest.team = BingoData.BingoSaves[ExpeditionData.slugcatPlayer].team;
@@ -1094,7 +1090,7 @@ namespace BingoMode
             {
                 if (bingoPage.TryGetValue(self, out var page))
                 {
-                    self.selectedObject = page.randomize;
+                    self.selectedObject = page.grid;
                 }
                 else self.selectedObject = self.characterSelect.slugcatButtons[0];
             }

--- a/BingoMode/BingoMenu/BingoButton.cs
+++ b/BingoMode/BingoMenu/BingoButton.cs
@@ -207,7 +207,7 @@ namespace BingoMode.BingoMenu
                     infoLabel.text += "\nCompleted by: ";
                     for (int i = 0; i < (challenge as BingoChallenge).TeamsCompleted.Length; i++)
                     {
-                        if ((challenge as BingoChallenge).TeamsCompleted[i]) infoLabel.text += BingoPage.TeamName(i) + ", ";
+                        if ((challenge as BingoChallenge).TeamsCompleted[i]) infoLabel.text += BingoPage.TeamName[i] + ", ";
                     }
                     infoLabel.text = infoLabel.text.Substring(0, infoLabel.text.Length - 2); // Trim the last ", "
                 }

--- a/BingoMode/BingoMenu/BingoGrid.cs
+++ b/BingoMode/BingoMenu/BingoGrid.cs
@@ -21,31 +21,42 @@ namespace BingoMode.BingoMenu
             GenerateBoardButtons();
         }
 
+        public override void Singal(MenuObject sender, string message)
+        {
+            if (message == "SWITCH")
+            {
+                BingoButton chal = sender as BingoButton;
+                BingoHooks.GlobalBoard.SwitchChals(chal.challenge, chal.x, chal.y);
+                return;
+            }
+
+            base.Singal(sender, message);
+        }
+
         public void Switch(bool off)
         {
-            for (int i = 0; i < challengeButtons.GetLength(0); i++)
-            {
-                for (int j = 0; j < challengeButtons.GetLength(1); j++)
-                {
+            for (int j = 0; j < challengeButtons.GetLength(1); j++)
+                for (int i = 0; i < challengeButtons.GetLength(0); i++)
                     challengeButtons[i, j].buttonBehav.greyedOut = off;
-                }
-            }
         }
 
         public void GenerateBoardButtons()
         {
             challengeButtons = new BingoButton[size, size];
-            for (int i = 0; i < board.challengeGrid.GetLength(0); i++)
+            for (int j = 0; j < board.challengeGrid.GetLength(1); j++)
             {
-                for (int j = 0; j < board.challengeGrid.GetLength(1); j++)
+                for (int i = 0; i < board.challengeGrid.GetLength(0); i++)
                 {
                     float butSize = maxSize / size;
                     float topLeft = -butSize * size / 2f;
-                    BingoButton but = new BingoButton(menu, this,
-                    centerPos - new Vector2(butSize / 2f, butSize / 2f) + new Vector2(topLeft + i * butSize + butSize / 2f, -topLeft - j * butSize - butSize / 2f - 50f), new Vector2(butSize, butSize), i + " " + j, i, j)
-                    {
-                        lastPos = pos
-                    };
+                    BingoButton but = new(
+                            menu,
+                            this,
+                            centerPos - new Vector2(butSize / 2f, butSize / 2f) + new Vector2(topLeft + i * butSize + butSize / 2f, -topLeft - j * butSize - butSize / 2f - 50f),
+                            new Vector2(butSize, butSize),
+                            i + " " + j,
+                            i,
+                            j);
                     challengeButtons[i, j] = but;
                     subObjects.Add(but);
                 }

--- a/BingoMode/BingoMenu/BingoPage.cs
+++ b/BingoMode/BingoMenu/BingoPage.cs
@@ -13,7 +13,6 @@ using UnityEngine;
 
 namespace BingoMode.BingoMenu
 {
-    using BingoMode.BingoRandomizer;
     using BingoSteamworks;
     using System;
     using static BingoMode.BingoSteamworks.LobbySettings;
@@ -21,62 +20,44 @@ namespace BingoMode.BingoMenu
     public class BingoPage : PositionedMenuObject
     {
         public ExpeditionMenu expMenu;
+
+        #region Title
+        private const float TITLE_MARGIN = 36f;
+        private const float TITLE_WIDTH = 164f; // source : atlases/bingomode.txt
+        private const float TITLE_HEIGHT = 52f; // source : atlases/bingomode.txt
+        private const float BACK_BUTTON_SIZE = 45f;
+        private const float TITLE_SPRITE_ALIGN = 5f;
+
+        private FSprite title;
+        private SymbolButton back;
+        #endregion
+
         public BingoBoard board;
         public BingoGrid grid;
-        public int size;
-        public FSprite pageTitle;
-        public SymbolButton rightPage;
-        public HoldButton startGame;
-        public SymbolButton randomize;
-        public SymbolButton shuffle;
-        public SymbolButton filter;
-        public OpHoldButton unlocksButton;
-        public UIelementWrapper unlockWrapper;
-        public MenuTabWrapper menuTabWrapper;
-        public SymbolButton plusButton;
-        public SymbolButton minusButton;
-        public OpTextBox shelterSetting;
-        public ConfigurableBase shelterSettingConf;
-        public UIelementWrapper shelterSettingWrapper;
-        public MenuLabel shelterLabel;
-        public SimpleButton copyBoard;
-        public SimpleButton pasteBoard;
+        private BoardControls boardControls;
+        private GameControls gameControls;
         public SymbolButton eggButton;
 
-        // Multiplayer
-        public SimpleButton multiButton;
-        public RoundedRect multiMenuBg;
-        public FSprite divider;
-        public SymbolButton createLobby;
-        public SimpleButton friendsNoFriends;
-        public SimpleButton refreshSearch;
-        public OpTextBox nameFilter;
-        public ConfigurableBase nameFilterConf;
-        public UIelementWrapper nameFilterWrapper;
-        public List<LobbyInfo> foundLobbies;
-        public FSprite[] lobbyDividers;
-        public VerticalSlider slider;
-        public float sliderF;
-        readonly int[] maxItems = [18, 16];
-        public bool inLobby;
-        public MenuLabel lobbyName;
-        public SymbolButton lobbySettingsInfo;
-        public List<PlayerInfo> lobbyPlayers;
-        public float lobbySlideIn;
-        public float lastLobbySlideIn;
-        public float slideStep;
+        #region Multiplayer
+        private const float MULTIPLAYER_PANEL_WIDTH = 380f;
+        private const float MULTIPLAYER_PANEL_HEIGHT = 600f;
 
-        // Randomizer
-        public SimpleButton randomizerButton;
-        public RoundedRect randomizerMenuBg;
-        public SymbolButton randomizerUnloadButton;
-        public MenuLabel randomizerLabel;
-        public FSprite randomizerDivider;
-        public VerticalSlider randomizerSlider;
-        public float sliderRF;
-        public List<SimpleButton> randomizers = [];
-        public float randomizerSlideIn;
-        public float randomizerSlideStep;
+        public SimpleButton multiplayerButton;
+        private MultiplayerPanel multiplayerPanel;
+        public float multiplayerSlideIn;
+        public float multiplayerSlideStep;
+        public bool InLobby { get => multiplayerPanel.InLobby; }
+        #endregion
+
+        #region Randomizer
+        private const float RANDOMIZER_PANEL_WIDTH = 190f;
+        private const float RANDOMIZER_PANEL_HEIGHT = 300f;
+
+        private SimpleButton randomizerButton;
+        private RandomizerPanel randomizerPanel;
+        private float randomizerSlideIn;
+        private float randomizerSlideStep;
+        #endregion
 
         public static readonly float desaturara = 0.1f;
         public static readonly Color[] TEAM_COLOR =
@@ -91,142 +72,94 @@ namespace BingoMode.BingoMenu
             Custom.Saturate(new Color(0.3f, 0f, 1f), desaturara), // Hurricane
             Custom.Saturate(Color.grey, desaturara), // Spectator
         };
-
-        public static string TeamName(int teamIndex)
+        public static readonly string[] TeamName =
+        [
+            "Red",
+            "Blue",
+            "Green",
+            "Orange",
+            "Pink",
+            "Cyan",
+            "Black",
+            "Hurricane",
+            "Board view",
+        ];
+        public static readonly Dictionary<string, int> TeamNumber = new()
         {
-            switch (teamIndex)
-            {
-                case 0: return "Red";
-                case 1: return "Blue";
-                case 2: return "Green";
-                case 3: return "Orange";
-                case 4: return "Pink";
-                case 5: return "Cyan";
-                case 6: return "Black";
-                case 7: return "Hurricane";
-                case 8: return "Board view";
-            }
-            return "Change";
-        }
-
-        public static int TeamNumber(string teamName)
-        {
-            switch (teamName)
-            {
-                case "Red": return 0;
-                case "Blue": return 1;
-                case "Green": return 2;
-                case "Orange": return 3;
-                case "Pink": return 4;
-                case "Cyan": return 5;
-                case "Black": return 6;
-                case "Hurricane": return 7;
-                case "Board view": return 8;
-            }
-            return 0;
-        }
+            { "Red", 0 },
+            { "Blue", 1 },
+            { "Green", 2 },
+            { "Orange", 3 },
+            { "Pink", 4 },
+            { "Cyan", 5 },
+            { "Black", 6 },
+            { "Hurricane", 7 },
+            { "Board view", 8 },
+        };
 
         public BingoPage(Menu.Menu menu, MenuObject owner, Vector2 pos) : base(menu, owner, pos)
         {
             expMenu = menu as ExpeditionMenu;
             board = BingoHooks.GlobalBoard;
-            size = board.size;
             BingoData.BingoMode = false;
             BingoData.TeamsInBingo = [0];
 
-            pageTitle = new FSprite("bingotitle");
-            pageTitle.SetAnchor(0.5f, 0f);
-            pageTitle.x = 683f;
-            pageTitle.y = 680f;
-            pageTitle.shader = menu.manager.rainWorld.Shaders["MenuText"];
-            Container.AddChild(pageTitle);
+            Vector2 topCenter = new(menu.manager.rainWorld.screenSize.x / 2f, menu.manager.rainWorld.screenSize.y - TITLE_MARGIN);
+            title = new("bingotitle")
+            {
+                anchorX = 0.5f,
+                anchorY = 1f,
+                x = topCenter.x,
+                y = topCenter.y,
+                shader = menu.manager.rainWorld.Shaders["MenuText"]
+            };
+            Container.AddChild(title);
 
-            rightPage = new SymbolButton(menu, this, "Big_Menu_Arrow", "GOBACK", new Vector2(783f, 685f));
-            rightPage.symbolSprite.rotation = 90f;
-            rightPage.size = new Vector2(45f, 45f);
-            rightPage.roundedRect.size = rightPage.size;
-            subObjects.Add(rightPage);
+            back = new(
+                    menu,
+                    this,
+                    "Big_Menu_Arrow",
+                    "GOBACK",
+                    topCenter + new Vector2(TITLE_WIDTH / 2f + TITLE_MARGIN, -TITLE_HEIGHT + TITLE_SPRITE_ALIGN))
+            { size = Vector2.one * BACK_BUTTON_SIZE };
+            back.symbolSprite.rotation = 90f;
+            back.roundedRect.size = Vector2.one * BACK_BUTTON_SIZE;
+            subObjects.Add(back);
 
-            randomize = new SymbolButton(menu, this, "Sandbox_Randomize", "RANDOMIZE", new Vector2(530f, 690f));
-            randomize.size = new Vector2(30f, 30f);
-            randomize.roundedRect.size = randomize.size;
-            subObjects.Add(randomize);
+            boardControls = new(
+                    menu,
+                    this,
+                    topCenter + new Vector2(-TITLE_WIDTH / 2f - TITLE_MARGIN, -TITLE_HEIGHT / 2f),
+                    1f,
+                    0.5f);
+            subObjects.Add(boardControls);
 
-            shuffle = new SymbolButton(menu, this, "Menu_Symbol_Shuffle", "SHUFFLE", new Vector2(563f, 690f));
-            shuffle.size = new Vector2(30f, 30f);
-            shuffle.roundedRect.size = shuffle.size;
-            subObjects.Add(shuffle);
+            gameControls = new(
+                    menu,
+                    this,
+                    new Vector2(menu.manager.rainWorld.screenSize.x * 0.79f - 45f, 60f));
+            subObjects.Add(gameControls);
 
-            filter = new SymbolButton(menu, this, "filter", "FILTER", new Vector2(497f, 690f));
-            filter.size = new Vector2(30f, 30f);
-            filter.symbolSprite.scale = 0.8f;
-            filter.roundedRect.size = filter.size;
-            subObjects.Add(filter);
+            multiplayerButton = new SimpleButton(
+                    menu,
+                    this,
+                    "Multiplayer",
+                    "SWITCH_MULTIPLAYER",
+                    expMenu.exitButton.pos + new Vector2(0f, -40f),
+                    new Vector2(140f, 30f));
+            subObjects.Add(multiplayerButton);
+            multiplayerPanel = new(menu, this, Vector2.zero, new Vector2(MULTIPLAYER_PANEL_WIDTH, MULTIPLAYER_PANEL_HEIGHT));
+            subObjects.Add(multiplayerPanel);
 
-            float xx = menu.manager.rainWorld.screenSize.x * 0.79f;
-            float yy = 85f;
-            startGame = new HoldButton(menu, this, "BEGIN", "STARTBINGO",
-                new Vector2(xx + 75f, yy + 160f), 40f);
-            subObjects.Add(startGame);
-
-            menuTabWrapper = new MenuTabWrapper(menu, this);
-            subObjects.Add(menuTabWrapper);
-            unlocksButton = new OpHoldButton(new Vector2(xx, yy), new Vector2(150f, 50f), menu.Translate("CONFIGURE<LINE>PERKS & BURDENS").Replace("<LINE>", "\r\n"), 20f);
-            unlocksButton.OnPressDone += UnlocksButton_OnPressDone;
-            unlocksButton.description = " ";
-            unlockWrapper = new UIelementWrapper(menuTabWrapper, unlocksButton);
-
-            minusButton = new SymbolButton(menu, this, "minus", "REMOVESIZE", new Vector2(xx - 45f, yy + 5f));
-            minusButton.size = new Vector2(40f, 40f);
-            minusButton.roundedRect.size = minusButton.size;
-            subObjects.Add(minusButton);
-            plusButton = new SymbolButton(menu, this, "plus", "ADDSIZE", new Vector2(xx + 155f, yy + 5f));
-            plusButton.size = new Vector2(40f, 40f);
-            plusButton.roundedRect.size = plusButton.size;
-            subObjects.Add(plusButton);
-
-            shelterSettingConf = MenuModList.ModButton.RainWorldDummy.config.Bind<string>("_ShelterSettingBingo", "_", (ConfigAcceptableBase)null);
-            shelterSetting = new OpTextBox(shelterSettingConf as Configurable<string>, new Vector2(xx + 48, yy + 56), 100f);
-            shelterSetting.alignment = FLabelAlignment.Center;
-            shelterSetting.description = "The shelter players start in. Please type in a valid shelter's room name (CASE SENSITIVE), or 'random'";
-            shelterSetting.OnValueUpdate += ShelterSetting_OnValueUpdate;
-            shelterSetting.maxLength = 100;
-            shelterSettingWrapper = new UIelementWrapper(menuTabWrapper, shelterSetting);
-            shelterSetting.value = "random";
-
-            shelterLabel = new MenuLabel(menu, this, "Shelter: ", new Vector2(xx + 26f, yy + 69), default, false);
-            subObjects.Add(shelterLabel);
-
-            copyBoard = new SimpleButton(menu, this, "Copy board", "COPYTOCLIPBOARD", new Vector2(xx - 10f, yy - 25f), new Vector2(80f, 20f));
-            subObjects.Add(copyBoard);
-            pasteBoard = new SimpleButton(menu, this, "Paste board", "PASTEFROMCLIPBOARD", new Vector2(xx + 80f, yy - 25f), new Vector2(80f, 20f));
-            subObjects.Add(pasteBoard);
-
-            // Multigameplayguy
-            multiButton = new SimpleButton(menu, this, "Multiplayer", "SWITCH_MULTIPLAYER", expMenu.exitButton.pos + new Vector2(0f, -40f), new Vector2(140f, 30f));
-            subObjects.Add(multiButton);
-            multiMenuBg = new RoundedRect(menu, this, default, new Vector2(380f, 600f), true);
-            subObjects.Add(multiMenuBg);
-
-            divider = new FSprite("pixel");
-            divider.scaleX = 380f;
-            divider.scaleY = 2f;
-            divider.anchorX = 0f;
-            Container.AddChild(divider);
-
-            nameFilterConf = MenuModList.ModButton.RainWorldDummy.config.Bind<string>("_NameFilterBingo", "", (ConfigAcceptableBase)null);
-            CreateSearchPage();
-
-            slider = new VerticalSlider(menu, this, "", new Vector2(375f, 47f), new Vector2(30f, 500f), BingoEnums.MultiplayerSlider, true) { floatValue = 1f };
-            //foreach (var line in slider.lineSprites)
-            //{
-            //    line.alpha = 0f;
-            //}
-            //slider.subtleSliderNob.outerCircle.alpha = 0f;
-            subObjects.Add(slider);
-            sliderF = 1f;
-
-            ConstructRandomizerPanel();
+            randomizerButton = new(
+                    menu,
+                    this,
+                    "Profiles",
+                    "SWITCH_RANDOMIZATION",
+                    expMenu.manualButton.pos + new Vector2(0, -40f), expMenu.manualButton.size);
+            subObjects.Add(randomizerButton);
+            randomizerPanel = new(menu, this, Vector2.zero, new Vector2(RANDOMIZER_PANEL_WIDTH, RANDOMIZER_PANEL_HEIGHT));
+            subObjects.Add(randomizerPanel);
 
             if (ExpeditionData.ints.Sum() >= 8)
             {
@@ -237,111 +170,40 @@ namespace BingoMode.BingoMenu
             }
         }
 
-        private void ConstructRandomizerPanel()
-        {
-            randomizerButton = new(menu, this, "Profiles", "SWITCH_RANDOMIZATION", expMenu.manualButton.pos + new Vector2(0, -40f), expMenu.manualButton.size);
-            subObjects.Add(randomizerButton);
-            randomizerMenuBg = new(menu, this, randomizerButton.pos + new Vector2(200f, 325f), new Vector2(190f, 300f), true);
-            subObjects.Add(randomizerMenuBg);
-            randomizerUnloadButton = new(menu, this, "Menu_Symbol_Clear_All", "UNLOADR", randomizerMenuBg.pos);
-            subObjects.Add(randomizerUnloadButton);
-            randomizerLabel = new(menu, this, "unloaded", randomizerMenuBg.pos, new Vector2(50f, 20f), false);
-            randomizerLabel.label.alignment = FLabelAlignment.Left;
-            subObjects.Add(randomizerLabel);
-            randomizerDivider = new("pixel")
-            {
-                scaleX = randomizerMenuBg.size.x,
-                scaleY = 2f,
-                anchorX = 0f,
-                y = 583f
-            };
-            randomizerSlider = new(menu, this, "", new Vector2(0f, randomizerDivider.y - randomizerMenuBg.size.y + 65f), new Vector2(30f, randomizerMenuBg.size.y - 100f), BingoEnums.RandomizerSlider, true) { floatValue = 1f };
-            subObjects.Add(randomizerSlider);
-            Container.AddChild(randomizerDivider);
-        }
-
-        private void ShelterSetting_OnValueUpdate(UIconfig config, string value, string oldValue)
-        {
-
-            string lastDen = BingoData.BingoDen;
-            if (value.Trim() == string.Empty)
-            {
-                BingoData.BingoDen = "random";
-                return;
-            }
-            BingoData.BingoDen = value;
-
-        }
-
-        private void NameFilter_OnValueUpdate(UIconfig config, string value, string oldValue)
-        {
-            SteamTest.CurrentFilters.text = value;
-            SteamTest.GetJoinableLobbies();
-        }
-
         public void UpdateLobbyHost(bool isHost)
         {
-            shelterSetting.greyedOut = !isHost;
-            randomize.buttonBehav.greyedOut = !isHost;
-            shuffle.buttonBehav.greyedOut = !isHost;
-            filter.buttonBehav.greyedOut = !isHost;
-            plusButton.buttonBehav.greyedOut = !isHost;
-            minusButton.buttonBehav.greyedOut = !isHost;
-            pasteBoard.buttonBehav.greyedOut = !isHost;
+            gameControls.HostPrivilege = isHost;
+            boardControls.HostPrivilege = isHost;
             randomizerButton.buttonBehav.greyedOut = !isHost;
             grid.Switch(!isHost);
 
-            if (isHost)
-            {
-                startGame.signalText = "STARTBINGO";
-                startGame.menuLabel.text = "BEGIN";
-                lobbySettingsInfo.UpdateSymbol("settingscog");
-                lobbySettingsInfo.signalText = "CHANGE_SETTINGS";
-
-                return;
-            }
-            startGame.signalText = "GETREADY";
-            startGame.menuLabel.text = "I'M\nREADY";
-            lobbySettingsInfo.UpdateSymbol("Menu_InfoI");
-            lobbySettingsInfo.signalText = "INFO_SETTINGS";
+            multiplayerPanel.UpdateLobbyHost(isHost);
         }
 
         public void Switch(bool toInLobby, bool create) // (nintendo reference
         {
-            if (inLobby == toInLobby) return;
-            inLobby = toInLobby;
+            if (InLobby == toInLobby)
+                return;
+
+            if (toInLobby)
+                multiplayerPanel.SwitchToLobby(create);
+            else
+                multiplayerPanel.SwitchToSearch();
             if (toInLobby)
             {
                 if (BingoData.globalSettings.perks == AllowUnlocks.None)
-                {
                     ExpeditionGame.activeUnlocks.RemoveAll(x => x.StartsWith("unl-"));
-                }
                 if (BingoData.globalSettings.burdens == AllowUnlocks.None)
-                {
                     ExpeditionGame.activeUnlocks.RemoveAll(x => x.StartsWith("bur-"));
-                }
 
                 expMenu.exitButton.buttonBehav.greyedOut = true;
-                rightPage.buttonBehav.greyedOut = true;
-                if (!create)
-                {
-                    startGame.signalText = "GETREADY";
-                    startGame.menuLabel.text = "I'M\nREADY";
-                }
-                shelterSetting.greyedOut = !create;
-                randomize.buttonBehav.greyedOut = !create;
-                shuffle.buttonBehav.greyedOut = !create;
-                filter.buttonBehav.greyedOut = !create;
-                plusButton.buttonBehav.greyedOut = !create;
-                minusButton.buttonBehav.greyedOut = !create;
-                pasteBoard.buttonBehav.greyedOut = !create;
+                back.buttonBehav.greyedOut = true;
+                gameControls.HostPrivilege = create;
+                boardControls.HostPrivilege = create;
                 expMenu.manualButton.buttonBehav.greyedOut = true;
-                multiButton.menuLabel.text = "Leave Lobby";
-                multiButton.signalText = "LEAVE_LOBBY";
+                multiplayerButton.menuLabel.text = "Leave Lobby";
+                multiplayerButton.signalText = "LEAVE_LOBBY";
                 grid.Switch(!create);
-                RemoveSearchPage();
-                CreateLobbyPage();
-                GrafUpdate(menu.myTimeStacker);
                 return;
             }
 
@@ -349,25 +211,16 @@ namespace BingoMode.BingoMenu
             ExpeditionGame.activeUnlocks.RemoveAll(x => x.StartsWith("bur-"));
 
             expMenu.exitButton.buttonBehav.greyedOut = false;
-            rightPage.buttonBehav.greyedOut = false;
-            startGame.buttonBehav.greyedOut = false;
-            startGame.signalText = "STARTBINGO";
-            startGame.menuLabel.text = "BEGIN";
-            randomize.buttonBehav.greyedOut = false;
-            shuffle.buttonBehav.greyedOut = false;
-            filter.buttonBehav.greyedOut = false;
-            plusButton.buttonBehav.greyedOut = false;
-            minusButton.buttonBehav.greyedOut = false;
-            pasteBoard.buttonBehav.greyedOut = false;
+            back.buttonBehav.greyedOut = false;
+            gameControls.HostPrivilege = true;
+            boardControls.HostPrivilege = true;
             expMenu.manualButton.buttonBehav.greyedOut = false;
-            multiButton.menuLabel.text = "Multiplayer";
-            multiButton.signalText = "SWITCH_MULTIPLAYER";
+            multiplayerButton.menuLabel.text = "Multiplayer";
+            multiplayerButton.signalText = "SWITCH_MULTIPLAYER";
             grid.Switch(false);
-
-            RemoveLobbyPage();
-            CreateSearchPage();
-            GrafUpdate(menu.myTimeStacker);
         }
+
+        public void UnlocksDialogClose() => gameControls.UnlocksDialogClose();
 
         public static string ExpeditionRandomStartsUnlocked(RainWorld rainWorld, SlugcatStats.Name slug)
         {
@@ -438,33 +291,33 @@ namespace BingoMode.BingoMenu
             return "SU_S01";
         }
 
+        public override void GrafUpdate(float timeStacker)
+        {
+            base.GrafUpdate(timeStacker);
+
+            title.SetPosition(DrawPos(timeStacker) + new Vector2(menu.manager.rainWorld.screenSize.x / 2f, menu.manager.rainWorld.screenSize.y - TITLE_MARGIN));
+
+            if (eggButton != null && expMenu.challengeSelect != null)
+            {
+                int num = ExpeditionGame.ExIndex(ExpeditionData.slugcatPlayer);
+                if (num > -1)
+                {
+                    eggButton.symbolSprite.color = ((ExpeditionData.ints[num] == 2) ? new HSLColor(Mathf.Sin(expMenu.challengeSelect.colorCounter / 20f), 1f, 0.75f).rgb : new Color(0.3f, 0.3f, 0.3f));
+                }
+            }
+
+            MultiplayerSlide(timeStacker);
+            RandomizerSlide(timeStacker);
+        }
+
         public override void Singal(MenuObject sender, string message)
         {
             base.Singal(sender, message);
 
-            if (message == "COPYTOCLIPBOARD")
-            {
-                UniClipboard.SetText(BingoHooks.GlobalBoard.ToString());
-                return;
-            }
-
-            if (message == "PASTEFROMCLIPBOARD")
-            {
-                BingoHooks.GlobalBoard.FromString(UniClipboard.GetText());
-                SteamTest.UpdateOnlineBingo();
-                return;
-            }
-
             if (message == "GOBACK")
             {
-                slideStep = -1f;
+                multiplayerSlideStep = -1f;
                 randomizerSlideStep = -1f;
-                slider.subtleSliderNob.outerCircle.alpha = 0f;
-                foreach (var line in slider.lineSprites)
-                {
-                    line.alpha = 0f;
-                }
-                ClearRandomizerList();
                 expMenu.manualButton.signalText = "MANUAL";
                 expMenu.manualButton.menuLabel.text = expMenu.Translate("MANUAL");
                 expMenu.UpdatePage(1);
@@ -482,16 +335,13 @@ namespace BingoMode.BingoMenu
                     BingoData.TeamsInBingo = [];
                     SpectatorHooks.Hook();
                 }
-                else BingoData.TeamsInBingo = [SteamTest.team];
+                else
+                    BingoData.TeamsInBingo = [SteamTest.team];
 
-                if (lobbyPlayers != null)
-                {
-                    foreach (var playere in lobbyPlayers)
-                    {
-                        int team = int.Parse(SteamMatchmaking.GetLobbyMemberData(SteamTest.CurrentLobby, playere.identity.GetSteamID(), "playerTeam"));
-                        if (!BingoData.TeamsInBingo.Contains(team) && team != 8) BingoData.TeamsInBingo.Add(team);
-                    }
-                }
+                List<PlayerData> players = SteamTest.GetPlayersData();
+                foreach (PlayerData player in players)
+                    if (!BingoData.TeamsInBingo.Contains(player.team) && player.team != 8)
+                        BingoData.TeamsInBingo.Add(player.team);
 
                 if (ModManager.JollyCoop && ModManager.CoopAvailable)
                 {
@@ -577,19 +427,17 @@ namespace BingoMode.BingoMenu
                     {
                         SteamFinal.ConnectedPlayers.Clear();
                         SteamFinal.ReceivedPlayerUpKeep = [];
-                        if (lobbyPlayers != null)
+                        foreach (var player in players)
                         {
-                            foreach (var player in lobbyPlayers)
-                            {
-                                if (player.identity.GetSteamID64() == SteamTest.selfIdentity.GetSteamID64()) continue;
-                                connectedPlayers += "bPlR" + player.identity.GetSteamID64();
-                                SteamFinal.ConnectedPlayers.Add(player.identity);
-                                SteamFinal.ReceivedPlayerUpKeep[player.identity.GetSteamID64()] = false;
-                                SteamFinal.SendUpKeepCounter = SteamFinal.PlayerUpkeepTime;
-                            }
+                            if (player.identity.GetSteamID64() == SteamTest.selfIdentity.GetSteamID64())
+                                continue;
+                            connectedPlayers += "bPlR" + player.identity.GetSteamID64();
+                            SteamFinal.ConnectedPlayers.Add(player.identity);
+                            SteamFinal.ReceivedPlayerUpKeep[player.identity.GetSteamID64()] = false;
+                            SteamFinal.SendUpKeepCounter = SteamFinal.PlayerUpkeepTime;
                         }
-                        if (connectedPlayers.StartsWith("bPlR")) connectedPlayers = connectedPlayers.Substring(4);
-
+                        if (connectedPlayers.StartsWith("bPlR"))
+                            connectedPlayers = connectedPlayers.Substring(4);
                     }
                     else if (!isHost)
                     {
@@ -603,7 +451,7 @@ namespace BingoMode.BingoMenu
                 }
                 else
                 {
-                    int newTeam = TeamNumber(Plugin.PluginInstance.BingoConfig.SinglePlayerTeam.Value);
+                    int newTeam = TeamNumber[Plugin.PluginInstance.BingoConfig.SinglePlayerTeam.Value];
 
                     BingoData.BingoSaves[ExpeditionData.slugcatPlayer] = new(BingoHooks.GlobalBoard.size, false, newTeam, false, false);
                     SteamTest.team = newTeam;
@@ -621,52 +469,6 @@ namespace BingoMode.BingoMenu
                 return;
             }
 
-            if (message == "RANDOMIZE")
-            {
-                Regen(false);
-                return;
-            }
-
-            if (message == "SHUFFLE")
-            {
-                Shuffle();
-                return;
-            }
-
-            if (message == "FILTER")
-            {
-                OpenFilterDialog();
-                return;
-            }
-
-            if (message == "SWITCH")
-            {
-                SwitchChals(sender);
-                return;
-            }
-
-            if (message == "ADDSIZE")
-            {
-                int lastSize = BingoHooks.GlobalBoard.size;
-                BingoHooks.GlobalBoard.size = Mathf.Min(lastSize + 1, 9);
-                if (lastSize != BingoHooks.GlobalBoard.size) Regen(true);
-                return;
-            }
-
-            if (message == "REMOVESIZE")
-            {
-                int lastSize = BingoHooks.GlobalBoard.size;
-                BingoHooks.GlobalBoard.size = Mathf.Max(1, lastSize - 1);
-                if (lastSize != BingoHooks.GlobalBoard.size) Regen(true);
-                return;
-            }
-
-            if (message == "CREATE_LOBBY")
-            {
-                menu.manager.ShowDialog(new CreateLobbyDialog(menu.manager, this));
-                return;
-            }
-
             if (message == "LEAVE_LOBBY")
             {
                 SteamTest.LeaveLobby();
@@ -676,142 +478,13 @@ namespace BingoMode.BingoMenu
 
             if (message == "SWITCH_MULTIPLAYER")
             {
-                if (slideStep == 0f) slideStep = 1f;
-                else slideStep = -slideStep;
-                float ff = slideStep == 1f ? 1f : 0f;
-                if (slideStep == 1f) SteamTest.GetJoinableLobbies();
-                slider.subtleSliderNob.outerCircle.alpha = ff;
-                foreach (var line in slider.lineSprites)
-                {
-                    line.alpha = ff;
-                }
-                return;
-            }
-
-            if (message == "REFRESH_SEARCH")
-            {
-                RemoveLobbiesSprites();
-
-                SteamTest.GetJoinableLobbies();
-                return;
-            }
-
-            if (message == "TOGGLE_FRIENDSONLY")
-            {
-                SteamTest.CurrentFilters.friendsOnly = !SteamTest.CurrentFilters.friendsOnly;
-                friendsNoFriends.menuLabel.text = SteamTest.CurrentFilters.friendsOnly ? "Friends only: Yes" : "Friends only: No";
-                return;
-            }
-
-            if (message.StartsWith("JOIN-"))
-            {
-                if (SteamTest.CurrentLobby != default) return;
-                (sender as SimpleButton).buttonBehav.greyedOut = true;
-                if (ulong.TryParse(message.Split('-')[1], out ulong lobid))
-                {
-
-                    CSteamID lobbid = new CSteamID(lobid);
-                    string lobbyVersion = SteamMatchmaking.GetLobbyData(lobbid, "lobbyVersion");
-                    if (lobbyVersion != Plugin.VERSION)
-                    {
-                        menu.manager.ShowDialog(new InfoDialog(menu.manager, $"Version mismatch.\nPlease make sure you're using the same Bingo mod version as the lobby.\nYour version: {Plugin.VERSION} Lobby version: {lobbyVersion}"));
-                        return;
-                    }
-                    string hostRequiredMods = SteamMatchmaking.GetLobbyData(lobbid, "hostMods");
-                    if (hostRequiredMods != "none")
-                    {
-                        List<string> modStrings = Regex.Split(hostRequiredMods, "<bMd>").ToList();
-
-                        Dictionary<string, string> requiredMods = [];
-                        string[] skipMods = GetCommonClientMods();
-                        foreach (string m in modStrings)
-                        {
-
-                            string[] idAndName = m.Split('|');
-                            if (skipMods.Contains(idAndName[0])) continue;
-
-                            requiredMods.Add(idAndName[0], idAndName[1]);
-                        }
-
-                        List<string> tooManyMods = [];
-                        foreach (var mod in ModManager.ActiveMods)
-                        {
-                            if (skipMods.Contains(mod.id)) continue;
-
-                            if (requiredMods.Keys.Count == 0)
-                            {
-                                tooManyMods.Add(mod.name);
-                            }
-
-                            if (requiredMods.Count > 0 && requiredMods.ContainsKey(mod.id)) requiredMods.Remove(mod.id);
-                        }
-
-                        if (tooManyMods.Count > 0)
-                        {
-                            menu.manager.ShowDialog(new InfoDialog(menu.manager, "Please disable these mods if you wish to join this lobby:\n-" + string.Join("\n- ", tooManyMods)));
-                            return;
-                        }
-                        if (requiredMods.Count > 0)
-                        {
-                            menu.manager.ShowDialog(new InfoDialog(menu.manager, "Please have all of these mods enabled if you wish to join this lobby:\n-" + string.Join("\n- ", requiredMods.Values)));
-                            return;
-                        }
-                    }
-
-                    string slug = SteamMatchmaking.GetLobbyData(lobbid, "slugcat");
-                    SlugcatSelectMenu.SaveGameData saveGameData = SlugcatSelectMenu.MineForSaveData(menu.manager, new SlugcatStats.Name(slug));
-                    if (saveGameData != null)
-                    {
-                        menu.manager.ShowDialog(new InfoDialog(menu.manager, $"You already have a saved game session as {SlugcatStats.getSlugcatName(new(slug))}.\nAre you sure you want to join this lobby?", lobbid));
-                        return;
-                    }
-
-                    var call = SteamMatchmaking.JoinLobby(lobbid);
-                    SteamTest.lobbyEntered.Set(call, SteamTest.OnLobbyEntered);
-                }
+                if (multiplayerSlideStep == 0f)
+                    multiplayerSlideStep = 1f;
                 else
-                {
-                    Plugin.logger.LogError("FAILED TO PARSE LOBBY ULONG FROM " + message);
-                    (sender as SimpleButton).buttonBehav.greyedOut = false;
-                }
-                return;
-            }
-
-            if (message == "CHANGE_SETTINGS")
-            {
-                menu.manager.ShowDialog(new CreateLobbyDialog(menu.manager, this, true, true));
-                return;
-            }
-
-            if (message == "INFO_SETTINGS")
-            {
-                menu.manager.ShowDialog(new CreateLobbyDialog(menu.manager, this, true, false));
-                return;
-            }
-
-            if (message.StartsWith("KICK-"))
-            {
-                ulong playerId = ulong.Parse(message.Split('-')[1], System.Globalization.NumberStyles.Any);
-                SteamNetworkingIdentity kickedPlayer = new SteamNetworkingIdentity();
-                kickedPlayer.SetSteamID64(playerId);
-                InnerWorkings.SendMessage("@", kickedPlayer);
-                return;
-            }
-
-            if (message.StartsWith("SWTEAM-"))
-            {
-                string[] data = message.Split('-');
-                ulong playerId = ulong.Parse(data[1], System.Globalization.NumberStyles.Any);
-                int playerTeam = int.Parse(data[2], System.Globalization.NumberStyles.Any);
-                if (playerId == SteamTest.selfIdentity.GetSteamID64())
-                {
-                    SteamTest.team = playerTeam;
-                    SteamMatchmaking.SetLobbyMemberData(SteamTest.CurrentLobby, "playerTeam", playerTeam.ToString());
-                    return;
-                }
-                SteamNetworkingIdentity playerIdentity = new SteamNetworkingIdentity();
-                playerIdentity.SetSteamID64(playerId);
-                InnerWorkings.SendMessage("%" + playerTeam, playerIdentity);
+                    multiplayerSlideStep = -multiplayerSlideStep;
+                float ff = multiplayerSlideStep == 1f ? 1f : 0f;
+                if (multiplayerSlideStep == 1f)
+                    SteamTest.GetJoinableLobbies();
                 return;
             }
 
@@ -830,958 +503,73 @@ namespace BingoMode.BingoMenu
                 return;
             }
 
-            if (message == "GETREADY")
-            {
-                SteamMatchmaking.SetLobbyMemberData(SteamTest.CurrentLobby, "ready", "1");
-                startGame.signalText = "GETUNREADY";
-                startGame.menuLabel.text = "I'M NOT\nREADY";
-                menu.PlaySound(SoundID.MENU_Start_New_Game);
-            }
-
-            if (message == "GETUNREADY")
-            {
-                SteamMatchmaking.SetLobbyMemberData(SteamTest.CurrentLobby, "ready", "0");
-                startGame.signalText = "GETREADY";
-                startGame.menuLabel.text = "I'M\nREADY";
-                menu.PlaySound(SoundID.MENU_Start_New_Game);
-            }
-
             if (message == "SWITCH_RANDOMIZATION")
             {
                 if (randomizerSlideStep == 0f) randomizerSlideStep = 1f;
                 else randomizerSlideStep = -randomizerSlideStep;
                 float ff = randomizerSlideStep == 1f ? 1f : 0f;
-                if (randomizerSlideStep == 1f)
-                    PopulateRandomizerList();
-                else
-                    ClearRandomizerList();
                 return;
-            }
-            
-            if (message.StartsWith("LOADR-"))
-            {
-                string profileName = message.Split('-')[1];
-                try
-                {
-                    BingoRandomizationProfile.LoadFromFile(profileName);
-                    randomizerLabel.text = profileName;
-                }
-                catch (Exception e)
-                {
-                    Plugin.logger.LogError($"Error loading profile {profileName} : {e.Message}");
-                }
-                return;
-            }
-
-            if (message == "UNLOADR")
-            {
-                BingoRandomizationProfile.Unload();
-                randomizerLabel.text = "unloaded";
-                return;
-            }
-        }
-
-        public static string[] GetCommonClientMods()
-        {
-            return ["bro.mergefix",
-                "pjb3005.sharpener",
-                "kevadroz.no_mod_update_confirm",
-                "Gamer025.RemixAutoRestart",
-                "willowwisp.audiofix",
-                "rwremix",
-                "dressmyslugcat",
-                "fastrollbutton",
-                "greyscreen",
-                "vigaro.guardian",
-                "healthbars",
-                "improved-input-confirm",
-                "franklygd.killfeed",
-                "lsbjorn52.ModPresets",
-                "notchoc.ModTags",
-                "sabreml.musicannouncements",
-                "SBCameraScroll",
-                "slime-cubed.inputdisplay",
-                "googlyeyes",
-                "rebinddevtools"];
-        }
-
-        public void ResetPlayerLobby()
-        {
-            RemovePlayerInfoSprites();
-            CreateLobbyPlayers();
-        }
-
-        public void Regen(bool sizeChange)
-        {
-            BingoHooks.GlobalBoard.GenerateBoard(BingoHooks.GlobalBoard.size, sizeChange);
-            //if (grid != null)
-            //{
-            //    grid.RemoveSprites();
-            //    RemoveSubObject(grid);
-            //    grid = null;
-            //}
-            //grid = new BingoGrid(menu, page, new(menu.manager.rainWorld.screenSize.x / 2f, menu.manager.rainWorld.screenSize.y / 2f), 500f);
-            //subObjects.Add(grid);
-            menu.PlaySound(SoundID.MENU_Next_Slugcat);
-        }
-
-        public void Shuffle()
-        {
-            BingoHooks.GlobalBoard.ShuffleBoard();
-            menu.PlaySound(SoundID.MENU_Next_Slugcat);
-        }
-
-        public void OpenFilterDialog()
-        {
-            menu.manager.ShowDialog(new FilterDialog(menu.manager));
-            menu.PlaySound(SoundID.MENU_Button_Standard_Button_Pressed);
-        }
-
-        public void SwitchChals(MenuObject sender)
-        {
-            BingoButton chal = sender as BingoButton;
-            BingoHooks.GlobalBoard.SwitchChals(chal.challenge, chal.x, chal.y);
-        }
-
-        public override void GrafUpdate(float timeStacker)
-        {
-            base.GrafUpdate(timeStacker);
-
-            pageTitle.x = Mathf.Lerp(owner.page.lastPos.x, owner.page.pos.x, timeStacker) + 680f;
-            pageTitle.y = Mathf.Lerp(owner.page.lastPos.y, owner.page.pos.y, timeStacker) + 680f;
-
-            if (eggButton != null && expMenu.challengeSelect != null)
-            {
-                int num = ExpeditionGame.ExIndex(ExpeditionData.slugcatPlayer);
-                if (num > -1)
-                {
-                    eggButton.symbolSprite.color = ((ExpeditionData.ints[num] == 2) ? new HSLColor(Mathf.Sin(expMenu.challengeSelect.colorCounter / 20f), 1f, 0.75f).rgb : new Color(0.3f, 0.3f, 0.3f));
-                }
-            }
-
-            float slide = Mathf.Lerp(lastLobbySlideIn, lobbySlideIn, timeStacker);
-            multiMenuBg.pos = multiButton.pos - new Vector2(25f, 625f) + Vector2.left * (1f - Custom.LerpExpEaseInOut(0f, 1f, slide)) * 1000f;
-            lastLobbySlideIn = lobbySlideIn;
-            lobbySlideIn = Mathf.Clamp01(lobbySlideIn + slideStep * 0.05f);
-            slider.pos.x = multiMenuBg.pos.x + 350f;
-            foreach (var line in slider.lineSprites)
-            {
-                line.x = multiMenuBg.pos.x + 365f;
-            }
-            divider.x = multiMenuBg.pos.x;
-            divider.y = 583f;
-
-            RandomizerSlide(timeStacker);
-            DrawProfileList(timeStacker);
-
-            if (!inLobby)
-            {
-                createLobby.pos.x = multiMenuBg.pos.x + 338f;
-                createLobby.pos.y = divider.y + 5.25f;
-
-                friendsNoFriends.pos.x = createLobby.pos.x - 117f;
-                friendsNoFriends.pos.y = createLobby.pos.y + 5f;
-
-                refreshSearch.pos.x = friendsNoFriends.pos.x - 67f;
-                refreshSearch.pos.y = createLobby.pos.y + 5f;
-
-                nameFilter.PosX = refreshSearch.pos.x - 147f;
-                nameFilter.PosY = createLobby.pos.y + 5f;
-
-                if (foundLobbies != null && foundLobbies.Count > 0) DrawDisplayedLobbies(timeStacker);
-                return;
-            }
-
-            lobbyName.pos.x = divider.x + 190f;
-            lobbyName.pos.y = divider.y + 25.25f;
-            lobbyName.lastPos = lobbyName.pos;
-
-            lobbySettingsInfo.pos.x = multiMenuBg.pos.x + 338f;
-            lobbySettingsInfo.pos.y = divider.y + 5.25f;
-            lobbySettingsInfo.lastPos = lobbySettingsInfo.pos;
-
-            if (lobbyPlayers != null && lobbyPlayers.Count > 0) DrawPlayerInfo(timeStacker);
-        }
-
-        private void RandomizerSlide(float timeStacker)
-        {
-            randomizerSlideIn = Mathf.Clamp01(randomizerSlideIn + randomizerSlideStep * 0.05f);
-            randomizerMenuBg.pos = randomizerButton.pos - new Vector2(-25f + randomizerMenuBg.size.x - randomizerButton.size.x, 325f) + Vector2.right * (1f - Custom.LerpExpEaseInOut(0f, 1f, randomizerSlideIn)) * 250f;
-            randomizerUnloadButton.pos = randomizerMenuBg.pos + new Vector2(10f, randomizerMenuBg.size.y - randomizerUnloadButton.size.y - 13f);
-            randomizerLabel.pos = randomizerUnloadButton.pos + new Vector2(5f, 3f);
-            randomizerDivider.x = randomizerMenuBg.pos.x;
-            randomizerSlider.pos.x = randomizerMenuBg.pos.x + randomizerMenuBg.size.x - randomizerSlider.size.x - 5f;
-            foreach (var line in randomizerSlider.lineSprites)
-                line.x = randomizerSlider.pos.x + randomizerSlider.size.x / 2f;
-
-            MenuObject owner = randomizerSlideIn >= 0.99f ? this : null;
-            randomizerMenuBg.owner = owner;
-            randomizerUnloadButton.owner = owner;
-            randomizerLabel.owner = owner;
-            randomizerSlider.subtleSliderNob.outerCircle.alpha = (owner != null && randomizers.Count >= 13) ? 1f : 0f;
-            foreach (var line in randomizerSlider.lineSprites)
-                line.alpha = (owner != null && randomizers.Count >= 13) ? 1f : 0f;
-        }
-
-        public override void Update()
-        {
-            base.Update();
-            multiButton.buttonBehav.greyedOut = !SteamTest.MultiplayerEnabled;
-            if (!BingoData.MultiplayerGame) return;
-            if (SteamTest.CurrentLobby == default)
-            {
-                rightPage.buttonBehav.greyedOut = false;
-                startGame.buttonBehav.greyedOut = false;
-                expMenu.exitButton.buttonBehav.greyedOut = false;
-            }
-            else
-            {
-                rightPage.buttonBehav.greyedOut = true;
-                expMenu.exitButton.buttonBehav.greyedOut = true;
-                //bool isHost = SteamTest.selfIdentity.GetSteamID() == SteamMatchmaking.GetLobbyOwner(SteamTest.CurrentLobby);
-                //if (isHost)
-                //{
-                //    bool allReady = true;
-
-                //    if (lobbyPlayers != null)
-                //    {
-                //        foreach (var player in lobbyPlayers)
-                //        {
-                //            allReady &= SteamMatchmaking.GetLobbyMemberData(SteamTest.CurrentLobby, player.identity.GetSteamID(), "ready") == "1";
-                //        }
-                //    }
-
-                //    startGame.buttonBehav.greyedOut = !allReady;
-                //}
-                //else
-                //{
-                //    startGame.buttonBehav.greyedOut = false;
-                //}
             }
         }
 
         public override void RemoveSprites()
         {
             base.RemoveSprites();
-            pageTitle.RemoveFromContainer();
-            unlocksButton.Hide();
-            shelterSetting.Hide();
-            unlocksButton.Unload();
-            shelterSetting.Unload();
-            shelterSetting.OnValueUpdate -= ShelterSetting_OnValueUpdate;
-            nameFilter.OnValueUpdate -= NameFilter_OnValueUpdate;
-            menuTabWrapper.wrappers.Remove(unlocksButton);
-            menuTabWrapper.wrappers.Remove(shelterSetting);
-            menuTabWrapper.wrappers.Remove(nameFilter);
-            menuTabWrapper.subObjects.Remove(unlockWrapper);
-            menuTabWrapper.subObjects.Remove(shelterSettingWrapper);
-            menuTabWrapper.subObjects.Remove(nameFilterWrapper);
-            if (inLobby) RemoveLobbyPage();
-            else RemoveSearchPage();
+
+            title.RemoveFromContainer();
+            foreach (MenuObject obj in subObjects)
+            {
+                obj.RemoveSprites();
+                RecursiveRemoveSelectables(obj);
+            }
+            subObjects.Clear();
         }
 
-        public void CreateLobbyPage()
+        public void ResetPlayerLobby() => multiplayerPanel.ResetPlayerLobby();
+
+        private void MultiplayerSlide(float timeStacker)
         {
-            lobbyName = new MenuLabel(expMenu, this, SteamMatchmaking.GetLobbyData(SteamTest.CurrentLobby, "name"), default, default, true);
-            lobbyName.pos.x = divider.x + 190f;
-            lobbyName.pos.y = divider.y + 25.25f;
-            lobbyName.lastPos = lobbyName.pos;
-            subObjects.Add(lobbyName);
-            bool isHost = SteamMatchmaking.GetLobbyOwner(SteamTest.CurrentLobby) == SteamTest.selfIdentity.GetSteamID();
-            lobbySettingsInfo = new SymbolButton(expMenu, this, isHost ? "settingscog" : "Menu_InfoI", isHost ? "CHANGE_SETTINGS" : "INFO_SETTINGS", default);
-            lobbySettingsInfo.size = new Vector2(35f, 35f);
-            lobbySettingsInfo.roundedRect.size = lobbySettingsInfo.size;
-            lobbySettingsInfo.symbolSprite.scale = 0.9f;
-            subObjects.Add(lobbySettingsInfo);
-
-            CreateLobbyPlayers();
+            const float DIST_TO_EDGE = MULTIPLAYER_PANEL_WIDTH + 50f;
+            const float OFFSET_TO_BUTTON_X = -25f; // left of button to left of panel
+            const float OFFSET_TO_BUTTON_Y = -25f; // bottom of button to top of panel
+            multiplayerSlideIn = Mathf.Clamp01(multiplayerSlideIn + multiplayerSlideStep * 0.05f);
+            multiplayerPanel.pos =
+                    multiplayerButton.pos
+                    + new Vector2(OFFSET_TO_BUTTON_X, OFFSET_TO_BUTTON_Y - MULTIPLAYER_PANEL_HEIGHT)
+                    + Vector2.left * (1f - Custom.LerpExpEaseInOut(0f, 1f, multiplayerSlideIn)) * DIST_TO_EDGE;
+            multiplayerPanel.Visible = multiplayerSlideIn >= 0.01f;
         }
 
-        public void RemoveLobbyPage()
+        private void RandomizerSlide(float timeStacker)
         {
-            lobbyName.RemoveSprites();
-            lobbySettingsInfo.RemoveSprites();
-            RemoveSubObject(lobbyName);
-            RemoveSubObject(lobbySettingsInfo);
-            RemovePlayerInfoSprites();
+            const float DIST_TO_EDGE = RANDOMIZER_PANEL_WIDTH + 50f;
+            const float OFFSET_TO_BUTTON_X = 25f; // right of button to right of panel
+            const float OFFSET_TO_BUTTON_Y = -25f; // bottom of button to top of panel
+            randomizerSlideIn = Mathf.Clamp01(randomizerSlideIn + randomizerSlideStep * 0.05f);
+            randomizerPanel.pos =
+                    randomizerButton.pos
+                    + new Vector2(randomizerButton.size.x + OFFSET_TO_BUTTON_X - RANDOMIZER_PANEL_WIDTH, OFFSET_TO_BUTTON_Y - RANDOMIZER_PANEL_HEIGHT)
+                    + Vector2.right * (1f - Custom.LerpExpEaseInOut(0f, 1f, randomizerSlideIn)) * DIST_TO_EDGE;
+            randomizerPanel.Visible = randomizerSlideIn >= 0.01f;
         }
 
-        public void CreateLobbyPlayers()
-        {
-            lobbyPlayers = [];
-            bool isHost = SteamMatchmaking.GetLobbyOwner(SteamTest.CurrentLobby) == SteamTest.selfIdentity.GetSteamID();
-
-            List<SteamNetworkingIdentity> identities = [];
-            int members = SteamMatchmaking.GetNumLobbyMembers(SteamTest.CurrentLobby);
-            bool allReady = true;
-
-            BingoData.MultiplayerGame = true;
-            for (int i = 0; i < members; i++)
-            {
-                SteamNetworkingIdentity member = new SteamNetworkingIdentity();
-                member.SetSteamID(SteamMatchmaking.GetLobbyMemberByIndex(SteamTest.CurrentLobby, i));
-                if (!identities.Contains(member)) identities.Add(member);
-
-                if (member.GetSteamID() != SteamMatchmaking.GetLobbyOwner(SteamTest.CurrentLobby)) allReady &= SteamMatchmaking.GetLobbyMemberData(SteamTest.CurrentLobby, member.GetSteamID(), "ready") == "1";
-            }
-
-            if (isHost) startGame.buttonBehav.greyedOut = !allReady;
-
-            foreach (var p in identities)
-            {
-                lobbyPlayers.Add(new PlayerInfo(this, p, isHost, SteamMatchmaking.GetLobbyMemberData(SteamTest.CurrentLobby, p.GetSteamID(), "ready") == "1"));
-            }
-
-            lobbyPlayers = lobbyPlayers.OrderBy(x => x.playerIndex).ToList();
-
-            if (lobbyPlayers.Count == 0)
-            {
-                Plugin.logger.LogMessage("No people in the lobby");
-            }
-
-            //lobbyDividers = new FSprite[lobbyPlayers.Count - 1];
-            // This could be negative and I think caused and OverflowException so rewritten.
-            lobbyDividers = new FSprite[Math.Max(0, lobbyPlayers.Count - 1)];
-            for (int i = 0; i < lobbyDividers.Length; i++)
-            {
-                lobbyDividers[i] = new FSprite("LinearGradient200")
-                {
-                    rotation = 90f,
-                    anchorY = 0f,
-                    scaleY = 1.5f
-                };
-                Container.AddChild(lobbyDividers[i]);
-            }
-
-            DrawPlayerInfo(menu.myTimeStacker);
-        }
-
-        private void PopulateRandomizerList()
-        {
-            foreach (string profile in BingoRandomizationProfile.GetAvailableProfiles())
-            {
-                SimpleButton button = new(menu, this, profile, $"LOADR-{profile}", new(randomizerMenuBg.pos.x, 0f), new(randomizerMenuBg.size.x - 50f, 16f));
-                randomizers.Add(button);
-                subObjects.Add(button);
-            }
-            randomizerSlider.floatValue = 1f;
-        }
-
-        private void ClearRandomizerList()
-        {
-            foreach (SimpleButton button in randomizers)
-            {
-                button.RemoveSprites();
-                RemoveSubObject(button);
-            }
-            randomizers.Clear();
-        }
-
-        public void CreateSearchPage()
-        {
-            createLobby = new SymbolButton(menu, this, "plus", "CREATE_LOBBY", default);
-            createLobby.size = new Vector2(35f, 35f);
-            createLobby.roundedRect.size = createLobby.size;
-            createLobby.symbolSprite.scale = 0.9f;
-            subObjects.Add(createLobby);
-
-            friendsNoFriends = new SimpleButton(menu, this, "Friends only: No", "TOGGLE_FRIENDSONLY", default, new Vector2(110f, 25f));
-            subObjects.Add(friendsNoFriends);
-
-            refreshSearch = new SimpleButton(menu, this, "Refresh", "REFRESH_SEARCH", default, new Vector2(60f, 25f));
-            subObjects.Add(refreshSearch);
-
-            nameFilter = new OpTextBox(nameFilterConf as Configurable<string>, default, 140f);
-            nameFilter.allowSpace = true;
-            nameFilter.OnValueUpdate += NameFilter_OnValueUpdate;
-
-            createLobby.pos.x = multiMenuBg.pos.x + 338f;
-            createLobby.pos.y = divider.y + 5.25f;
-
-            friendsNoFriends.pos.x = createLobby.pos.x - 117f;
-            friendsNoFriends.pos.y = createLobby.pos.y + 5f;
-
-            refreshSearch.pos.x = friendsNoFriends.pos.x - 67f;
-            refreshSearch.pos.y = createLobby.pos.y + 5f;
-
-            nameFilter.PosX = refreshSearch.pos.x - 147f;
-            nameFilter.PosY = createLobby.pos.y + 5f;
-            nameFilter.lastScreenPos = nameFilter.ScreenPos;
-
-            nameFilterWrapper = new UIelementWrapper(menuTabWrapper, nameFilter);
-        }
-
-        public void RemoveSearchPage()
-        {
-            createLobby.RemoveSprites();
-            friendsNoFriends.RemoveSprites();
-            refreshSearch.RemoveSprites();
-            RemoveSubObject(createLobby);
-            RemoveSubObject(friendsNoFriends);
-            RemoveSubObject(refreshSearch);
-            nameFilter.Hide();
-            nameFilter.Unload();
-            menuTabWrapper.wrappers.Remove(nameFilter);
-            menuTabWrapper.subObjects.Remove(nameFilterWrapper);
-            RemoveLobbiesSprites();
-        }
-
-        public void RemoveLobbiesSprites()
-        {
-            if (foundLobbies != null && foundLobbies.Count > 0)
-            {
-                for (int i = 0; i < foundLobbies.Count; i++)
-                {
-                    foundLobbies[i].Remove();
-                }
-                foundLobbies.Clear();
-            }
-            if (lobbyDividers != null)
-            {
-                for (int i = 0; i < lobbyDividers.Length; i++)
-                {
-                    lobbyDividers[i].RemoveFromContainer();
-                }
-            }
-        }
-
-        public void RemovePlayerInfoSprites()
-        {
-            if (lobbyPlayers != null && lobbyPlayers.Count > 0)
-            {
-                for (int i = 0; i < lobbyPlayers.Count; i++)
-                {
-                    lobbyPlayers[i].Remove();
-                }
-                lobbyPlayers = [];
-            }
-            if (lobbyDividers != null)
-            {
-                for (int i = 0; i < lobbyDividers.Length; i++)
-                {
-                    lobbyDividers[i].RemoveFromContainer();
-                }
-                lobbyDividers = [];
-            }
-        }
-
-        public void UnlocksButton_OnPressDone(UIfocusable trigger)
-        {
-            UnlockDialog unlockDialog = new UnlockDialog(menu.manager, (menu as ExpeditionMenu).challengeSelect);
-            unlocksButton.Reset();
-            unlocksButton.greyedOut = true;
-            if (BingoData.MultiplayerGame)
-            {
-                bool isHost = SteamMatchmaking.GetLobbyOwner(SteamTest.CurrentLobby) == SteamTest.selfIdentity.GetSteamID();
-                foreach (var perj in unlockDialog.perkButtons)
-                {
-                    perj.buttonBehav.greyedOut = perj.buttonBehav.greyedOut || BingoData.globalSettings.perks == AllowUnlocks.None || (BingoData.globalSettings.perks == AllowUnlocks.Inherited && !isHost);
-                }
-                foreach (var bur in unlockDialog.burdenButtons)
-                {
-                    bur.buttonBehav.greyedOut = bur.buttonBehav.greyedOut || BingoData.globalSettings.burdens == AllowUnlocks.None || (BingoData.globalSettings.burdens == AllowUnlocks.Inherited && !isHost);
-                }
-            }
-            string[] bannedBurdens = ["bur-doomed"];
-            string[] bannedPerks = ["unl-passage", "unl-karma"];
-            foreach (var bur in unlockDialog.burdenButtons)
-            {
-                if (bannedBurdens.Contains(bur.signalText))
-                {
-                    bur.buttonBehav.greyedOut = true;
-                    if (ExpeditionGame.activeUnlocks.Contains(bur.signalText)) unlockDialog.ToggleBurden(bur.signalText);
-                }
-            }
-            foreach (var per in unlockDialog.perkButtons)
-            {
-                if (bannedPerks.Contains(per.signalText))
-                {
-                    per.buttonBehav.greyedOut = true;
-                    if (ExpeditionGame.activeUnlocks.Contains(per.signalText)) unlockDialog.ToggleBurden(per.signalText);
-                }
-            }
-            menu.manager.ShowDialog(unlockDialog);
-        }
-
-        public void CreateDisplayedLobbies()
-        {
-            for (int i = 0; i < foundLobbies.Count; i++)
-            {
-                Container.AddChild(foundLobbies[i].nameLabel);
-                Container.AddChild(foundLobbies[i].playerLabel);
-            }
-
-            lobbyDividers = new FSprite[foundLobbies.Count - 1];
-            for (int i = 0; i < lobbyDividers.Length; i++)
-            {
-                lobbyDividers[i] = new FSprite("pixel")
-                {
-                    scaleX = 340f,
-                    scaleY = 1f,
-                    anchorX = 0f
-                };
-                Container.AddChild(lobbyDividers[i]);
-            }
-        }
-
-        public void DrawDisplayedLobbies(float timeStacker)
-        {
-            float refX = Mathf.Lerp(multiMenuBg.lastPos.x, multiMenuBg.pos.x, timeStacker) + 10f;
-            float dif = 500f / maxItems[0];
-            float sliderDif = dif * (foundLobbies.Count - maxItems[0] - 1);
-            Vector2 pouse = new Vector2(refX, 560f);
-            for (int i = 0; i < foundLobbies.Count; i++)
-            {
-                Vector2 origPos = pouse - new Vector2(0f, dif * i - sliderDif * (1f - (foundLobbies.Count < maxItems[0] ? 1f : sliderF)));
-                foundLobbies[i].maxAlpha = Mathf.InverseLerp(36f, 46f, origPos.y) - Mathf.InverseLerp(566f, 576f, origPos.y);
-                foundLobbies[i].Draw(origPos);
-            }
-            for (int i = 0; i < lobbyDividers.Length; i++)
-            {
-                Vector2 origPos = pouse - new Vector2(0f, dif * i - sliderDif * (1f - (foundLobbies.Count < maxItems[0] ? 1f : sliderF)));
-                lobbyDividers[i].alpha = Mathf.InverseLerp(60f, 70f, origPos.y) - Mathf.InverseLerp(566f, 576f, origPos.y);
-                lobbyDividers[i].SetPosition(origPos + new Vector2(2f, -12.5f));
-            }
-        }
-
-        public void DrawPlayerInfo(float timeStacker)
-        {
-            float refX = Mathf.Lerp(multiMenuBg.lastPos.x, multiMenuBg.pos.x, timeStacker) + 10f;
-            float dif = 500f / maxItems[0];
-            float sliderDif = dif * (lobbyPlayers.Count - maxItems[0] - 1);
-            Vector2 pouse = new Vector2(refX, 560f);
-            for (int i = 0; i < lobbyPlayers.Count; i++)
-            {
-                Vector2 origPos = pouse - new Vector2(0f, dif * i - sliderDif * (1f - (lobbyPlayers.Count < maxItems[0] ? 1f : sliderF)));
-                lobbyPlayers[i].maxAlpha = Mathf.InverseLerp(36f, 46f, origPos.y) - Mathf.InverseLerp(566f, 576f, origPos.y);
-                lobbyPlayers[i].Draw(origPos);
-            }
-            for (int i = 0; i < lobbyDividers.Length; i++)
-            {
-                Vector2 origPos = pouse - new Vector2(0f, dif * i - sliderDif * (1f - (lobbyPlayers.Count < maxItems[0] ? 1f : sliderF)));
-                lobbyDividers[i].alpha = Mathf.InverseLerp(60f, 70f, origPos.y) - Mathf.InverseLerp(566f, 576f, origPos.y);
-                lobbyDividers[i].SetPosition(origPos + new Vector2(2f, -12.5f));
-            }
-        }
-
-        private void DrawProfileList(float timeStacker)
-        {
-            const float deltaY = -20f;
-            float top = randomizerDivider.y - 20f;
-            float bottom = randomizerDivider.y - 248f;
-            float y = top + Mathf.Lerp(20f * (randomizers.Count - 12.4f), 0f, sliderRF);
-            foreach (SimpleButton button in randomizers)
-            {
-                button.pos.x = y > top || y < bottom ? randomizerMenuBg.pos.x + 250f : randomizerMenuBg.pos.x + 10f;
-                button.pos.y = y;
-                y += deltaY;
-            }
-        }
-
-        public void AddLobbies(List<CSteamID> lobbies)
-        {
-            //if (fromContinueGame)
-            //{
-            //    foreach (var lobby in lobbies)
-            //    {
-            //        ulong owner = SteamMatchmaking.GetLobbyOwner(lobby).m_SteamID;
-            //        if (owner != SteamTest.selfIdentity.GetSteamID64() && owner == BingoData.BingoSaves[ExpeditionData.slugcatPlayer].hostID.GetSteamID64())
-            //        {
-            //            var call = SteamMatchmaking.JoinLobby(lobby);
-            //            SteamTest.lobbyEntered.Set(call, SteamTest.OnLobbyEntered);
-            //            return;
-            //        }
-            //    }
-            //    return;
-            //}
-            RemoveLobbiesSprites();
-            foundLobbies = [];
-
-            foreach (var lobby in lobbies)
-            {
-                //Plugin.logger.LogMessage($"Examining lobby - {lobby}");
-                //int l = SteamMatchmaking.GetLobbyDataCount(lobby);
-                //for (int i = 0; i < l; i++)
-                //{
-                //    if (SteamMatchmaking.GetLobbyDataByIndex(lobby, i, out string key, 255, out string value, 8192))
-                //    {
-                //        Plugin.logger.LogMessage($"Data {i} - {key} - {value}");
-                //    }
-                //}
-                try
-                {
-                    string name = SteamMatchmaking.GetLobbyData(lobby, "name");
-                    //int maxPlayers = int.Parse(SteamMatchmaking.GetLobbyData(lobby, "maxPlayers"), System.Globalization.NumberStyles.Any);
-                    int currentPlayers = SteamMatchmaking.GetNumLobbyMembers(lobby);
-                    BingoData.BingoGameMode gamemode = (BingoData.BingoGameMode)int.Parse(SteamMatchmaking.GetLobbyData(lobby, "gamemode"), System.Globalization.NumberStyles.Any);
-                    bool hostMods = SteamMatchmaking.GetLobbyData(lobby, "hostMods") != "none";
-                    string lobbyVersion = SteamMatchmaking.GetLobbyData(lobby, "lobbyVersion");
-                    string slugcat = SteamMatchmaking.GetLobbyData(lobby, "slugcat");
-
-
-                    AllowUnlocks perks = (AllowUnlocks)(int.Parse(SteamMatchmaking.GetLobbyData(lobby, "perks").Trim(), System.Globalization.NumberStyles.Any));
-                    AllowUnlocks burdens = (AllowUnlocks)(int.Parse(SteamMatchmaking.GetLobbyData(lobby, "burdens").Trim(), System.Globalization.NumberStyles.Any));
-                    int maxPlayers = SteamMatchmaking.GetLobbyMemberLimit(lobby);
-
-                    foundLobbies.Add(new LobbyInfo(this, lobby, name, maxPlayers, currentPlayers, gamemode, hostMods, lobbyVersion, slugcat, perks, burdens));
-                    //
-                }
-                catch (System.Exception e)
-                {
-                    Plugin.logger.LogError("Failed to get lobby info from lobby " + lobby + ". Exception:\n" + e);
-                }
-            }
-
-            CreateDisplayedLobbies();
-        }
+        public void AddLobbies(List<CSteamID> lobbies) => multiplayerPanel.AddLobbies(lobbies);
 
         public void SliderSetValue(Slider slider, float f)
         {
             if (slider.ID == BingoEnums.MultiplayerSlider)
-                sliderF = f;
+                multiplayerPanel.sliderF = f;
             else if (slider.ID == BingoEnums.RandomizerSlider)
-                sliderRF = f;
+                randomizerPanel.sliderF = f;
         }
 
         public float ValueOfSlider(Slider slider)
         {
             if (slider.ID == BingoEnums.MultiplayerSlider)
-                return sliderF;
+                return multiplayerPanel.sliderF;
             if (slider.ID == BingoEnums.RandomizerSlider)
-                return sliderRF;
+                return randomizerPanel.sliderF;
             return 0f;
-        }
-
-        public void FocusOn(PlayerInfo exception)
-        {
-            ResetFocus();
-            int g = lobbyPlayers.IndexOf(exception) + 1;
-            for (int i = g; i < Mathf.Min(lobbyPlayers.Count, g + 4); i++)
-            {
-                lobbyPlayers[i].disabled = true;
-            }
-        }
-
-        public void ResetFocus()
-        {
-            for (int i = 0; i < lobbyPlayers.Count; i++)
-            {
-                lobbyPlayers[i].disabled = false;
-            }
-        }
-
-        public class PlayerInfo
-        {
-            public SteamNetworkingIdentity identity;
-            public string nickname;
-            public int team;
-            public SimpleButton kick;
-            public OpComboBox selectTeam;
-            public BingoPage page;
-            public FLabel nameLabel;
-            public float maxAlpha;
-            public int playerIndex;
-            public Configurable<string> conf;
-            public UIelementWrapper cWrapper;
-            public bool disabled;
-            public FSprite readyMark;
-
-            public PlayerInfo(BingoPage page, SteamNetworkingIdentity identity, bool controls, bool ready)
-            {
-                this.page = page;
-                this.identity = identity;
-                bool isSelf = identity.GetSteamID() == SteamTest.selfIdentity.GetSteamID();
-                bool isHost = identity.GetSteamID() == SteamMatchmaking.GetLobbyOwner(SteamTest.CurrentLobby);
-
-                int.TryParse(SteamMatchmaking.GetLobbyMemberData(SteamTest.CurrentLobby, identity.GetSteamID(), "playerTeam"), System.Globalization.NumberStyles.Any, null, out team);
-                int.TryParse(SteamMatchmaking.GetLobbyMemberData(SteamTest.CurrentLobby, identity.GetSteamID(), "playerIndex"), System.Globalization.NumberStyles.Any, null, out playerIndex);
-
-                nickname = isSelf ? SteamFriends.GetPersonaName() : SteamFriends.GetFriendPersonaName(identity.GetSteamID());
-                if (nickname == null) nickname = "???";
-                nickname += " (" + TeamName(team) + ")";
-
-                nameLabel = new FLabel(Custom.GetFont(), nickname)
-                {
-                    alignment = FLabelAlignment.Left,
-                    anchorX = 0,
-                    color = TEAM_COLOR[team]
-                };
-                page.Container.AddChild(nameLabel);
-
-                string markAtlas = isHost ? "TinyCrown" : ready ? "TinyCheck" : "TinyX";
-                Color markColor = isHost ? Color.yellow : ready ? Color.green : Color.red;
-                readyMark = new FSprite(markAtlas)
-                {
-                    color = markColor
-                };
-                page.Container.AddChild(readyMark);
-
-                if (controls)
-                {
-                    conf = MenuModList.ModButton.RainWorldDummy.config.Bind<string>("_PlayerInfoSelect", TeamName(team), (ConfigAcceptableBase)null);
-                    selectTeam = new OpComboBox(conf, new Vector2(-10000f, -10000f), 90f, new string[] { "Red", "Blue", "Green", "Orange", "Pink", "Cyan", "Black", "Hurricane", "Board view" });
-                    selectTeam.OnValueChanged += SelectTeam_OnValueChanged;
-                    selectTeam.OnListOpen += FocusThing;
-                    selectTeam.OnListClose += UnfocusThing;
-                    cWrapper = new UIelementWrapper(page.menuTabWrapper, selectTeam);
-                    if (!isSelf)
-                    {
-                        kick = new SimpleButton(page.menu, page, "Kick", "KICK-" + identity.GetSteamID64().ToString(), new Vector2(-10000f, -10000f), new Vector2(40f, 16f));
-                        page.subObjects.Add(kick);
-                    }
-                }
-            }
-
-            private void SelectTeam_OnValueChanged(UIconfig config, string value, string oldValue)
-            {
-                page.Singal(null, "SWTEAM-" + identity.GetSteamID64() + "-" + TeamNumber(value));
-            }
-
-            private void UnfocusThing(UIfocusable trigger)
-            {
-                page.ResetFocus();
-            }
-
-            private void FocusThing(UIfocusable trigger)
-            {
-                page.FocusOn(this);
-            }
-
-            public void Draw(Vector2 origPos)
-            {
-                nameLabel.SetPosition(origPos + new Vector2(8f, 0f));
-                readyMark.SetPosition(origPos);
-                float a = Mathf.Clamp01(maxAlpha);
-                bool unclicky = maxAlpha < 0.25f || disabled;
-                nameLabel.alpha = a;
-                readyMark.alpha = a;
-                if (selectTeam != null)
-                {
-                    selectTeam.myContainer.alpha = disabled ? 0f : a;
-                    selectTeam.pos = origPos + new Vector2(250f, -10.5f);
-                    selectTeam.lastScreenPos = selectTeam.ScreenPos;
-                    selectTeam.greyedOut = unclicky;
-                    selectTeam._lastGreyedOut = unclicky;
-                    if (unclicky) selectTeam._mouseDown = false;
-                }
-                if (kick != null)
-                {
-                    kick.pos = origPos + new Vector2(210f, -8f);
-                    kick.lastPos = kick.pos;
-                    kick.buttonBehav.greyedOut = unclicky;
-                    foreach (var sprite in kick.roundedRect.sprites)
-                    {
-                        sprite.alpha = disabled ? 0f : a;
-                    }
-                    kick.menuLabel.label.alpha = disabled ? 0f : a;
-                }
-            }
-
-            public void Remove()
-            {
-                nameLabel.RemoveFromContainer();
-                readyMark.RemoveFromContainer();
-                if (selectTeam != null)
-                {
-                    selectTeam.Hide();
-                    selectTeam.Unload();
-                    page.menuTabWrapper.wrappers.Remove(selectTeam);
-                    page.menuTabWrapper.subObjects.Remove(cWrapper);
-                }
-                if (kick != null)
-                {
-                    kick.RemoveSprites();
-                    page.RemoveSubObject(kick);
-                }
-            }
-        }
-
-        public class LobbyInfo
-        {
-            public CSteamID lobbyID;
-            public string name;
-            public int maxPlayers;
-            public int currentPlayers;
-            public BingoData.BingoGameMode gamemode;
-            public bool hostMods;
-            public string version;
-            public string slugcat;
-            public AllowUnlocks perks;
-            public AllowUnlocks burdens;
-            public FLabel nameLabel;
-            public FLabel playerLabel;
-            public float maxAlpha;
-            public SimpleButton clicky;
-            BingoPage page;
-            public InfoPanel panel;
-
-            public LobbyInfo(BingoPage page, CSteamID lobbyID, string name, int maxPlayers, int currentPlayers, BingoData.BingoGameMode gamemode, bool hostMods, string version, string slugcat, AllowUnlocks perks, AllowUnlocks burdens)
-            {
-                this.lobbyID = lobbyID;
-                this.name = name;
-                this.maxPlayers = maxPlayers;
-                this.currentPlayers = currentPlayers;
-                this.gamemode = gamemode;
-                this.hostMods = hostMods;
-                this.version = version;
-                this.slugcat = slugcat;
-                this.perks = perks;
-                this.burdens = burdens;
-                this.page = page;
-
-                nameLabel = new FLabel(Custom.GetFont(), name)
-                {
-                    alignment = FLabelAlignment.Left,
-                    anchorX = 0,
-                };
-                playerLabel = new FLabel(Custom.GetFont(), currentPlayers + "/" + maxPlayers);
-
-                clicky = new SimpleButton(page.menu, page, "", "JOIN-" + lobbyID.ToString(), default, new Vector2(352f, 20f));
-                page.subObjects.Add(clicky);
-
-                panel = new InfoPanel(page, this);
-            }
-
-            public void Draw(Vector2 origPos)
-            {
-                nameLabel.SetPosition(origPos);
-                playerLabel.SetPosition(origPos + new Vector2(335f, 0f));
-                float a = Mathf.Clamp01(maxAlpha); // - 0.5f * Mathf.Abs(Mathf.Sin(Mathf.Lerp(buttonBehav.lastSin, buttonBehav.sin, timeStacker) / 30f * Mathf.PI))
-                nameLabel.alpha = a;
-                playerLabel.alpha = a;
-
-                foreach (var sprit in clicky.roundedRect.sprites)
-                {
-                    sprit.alpha = 0f;
-                }
-                clicky.roundedRect.fillAlpha = 0f;
-                clicky.roundedRect.lasFillAplha = 0f;
-
-                clicky.pos = origPos - new Vector2(5f, 10f);
-                clicky.buttonBehav.greyedOut = a < 0.5f;
-
-                panel.visible = clicky.IsMouseOverMe && a > 0.5f;
-                panel.Draw(origPos + new Vector2(350f, 0f));
-            }
-
-            public void Remove()
-            {
-                nameLabel.RemoveFromContainer();
-                playerLabel.RemoveFromContainer();
-                clicky.RemoveSprites();
-                page.RemoveSubObject(clicky);
-                panel.Remove();
-            }
-
-            public class InfoPanel
-            {
-                public FSprite[] border;
-                public FSprite background;
-                public FLabel[] labels;
-                public bool visible;
-                readonly float width = 180f;
-                readonly float height = 100f;
-
-                public InfoPanel(BingoPage page, LobbyInfo info)
-                {
-                    background = new FSprite("pixel")
-                    {
-                        scaleX = width,
-                        scaleY = height,
-                        anchorX = 0f,
-                        anchorY = 0f,
-                        color = new Color(0.001f, 0.001f, 0.001f),
-                        alpha = 0.9f
-                    };
-                    page.Container.AddChild(background);
-
-                    border = new FSprite[4];
-                    for (int i = 0; i < 2; i++)
-                    {
-                        border[i] = new FSprite("pixel")
-                        {
-                            anchorX = 0f,
-                            anchorY = 0f,
-                            scaleX = width,
-                            scaleY = 2f,
-                            shader = page.menu.manager.rainWorld.Shaders["MenuText"]
-                        };
-                        page.Container.AddChild(border[i]);
-                    }
-                    for (int i = 2; i < 4; i++)
-                    {
-                        border[i] = new FSprite("pixel")
-                        {
-                            anchorX = 0f,
-                            anchorY = 0f,
-                            scaleX = 2f,
-                            scaleY = height,
-                            shader = page.menu.manager.rainWorld.Shaders["MenuText"]
-                        };
-                        page.Container.AddChild(border[i]);
-                    }
-
-                    labels = new FLabel[6];
-                    for (int i = 0; i < labels.Length; i++)
-                    {
-                        labels[i] = new FLabel(Custom.GetFont(), "")
-                        {
-                            shader = page.menu.manager.rainWorld.Shaders["MenuText"],
-                            anchorX = 0f,
-                            anchorY = 0f,
-                            alignment = FLabelAlignment.Center
-                        };
-                        page.Container.AddChild(labels[i]);
-                    }
-
-                    labels[0].text = "Game mode: " + info.gamemode;
-                    labels[1].text = "Mod version: " + info.version;
-                    labels[2].text = "Perks: " + (info.perks == AllowUnlocks.Any ? "Allowed" : info.perks == AllowUnlocks.None ? "Disabled" : "Host decides");
-                    labels[3].text = "Burdens: " + (info.burdens == AllowUnlocks.Any ? "Allowed" : info.burdens == AllowUnlocks.None ? "Disabled" : "Host decides");
-                    labels[4].text = "Require host's mods: " + (info.hostMods ? "Yes" : "No");
-                    labels[5].text = "Slugcat: " + SlugcatStats.getSlugcatName(new(info.slugcat));
-                }
-
-                public void Draw(Vector2 pos)
-                {
-                    pos.y -= height / 2f;
-                    for (int i = 0; i < border.Length; i++)
-                    {
-                        border[i].isVisible = visible;
-                    }
-                    for (int i = 0; i < labels.Length; i++)
-                    {
-                        labels[i].isVisible = visible;
-                    }
-                    background.isVisible = visible;
-                    border[0].SetPosition(pos);
-                    border[1].SetPosition(pos + new Vector2(0f, height));
-                    border[2].SetPosition(pos);
-                    border[3].SetPosition(pos + new Vector2(width, 0f));
-                    background.SetPosition(pos);
-                    float xDif = width / 2f;
-                    float yDif = height / labels.Length;
-                    labels[0].SetPosition(pos + new Vector2(xDif + 0.01f, 1.5f + yDif * 5f));
-                    labels[1].SetPosition(pos + new Vector2(xDif + 0.01f, 1.5f + yDif * 4f));
-                    labels[2].SetPosition(pos + new Vector2(xDif + 0.01f, 1.5f + yDif * 3f));
-                    labels[3].SetPosition(pos + new Vector2(xDif + 0.01f, 1.5f + yDif * 2));
-                    labels[4].SetPosition(pos + new Vector2(xDif + 0.01f, 1.5f + yDif));
-                    labels[5].SetPosition(pos + new Vector2(xDif + 0.01f, 1.5f));
-                }
-
-                public void Remove()
-                {
-                    for (int i = 0; i < border.Length; i++)
-                    {
-                        border[i].RemoveFromContainer();
-                    }
-                    for (int i = 0; i < labels.Length; i++)
-                    {
-                        labels[i].RemoveFromContainer();
-                    }
-                    background.RemoveFromContainer();
-                }
-            }
         }
     }
 }

--- a/BingoMode/BingoMenu/BoardControls.cs
+++ b/BingoMode/BingoMenu/BoardControls.cs
@@ -1,0 +1,124 @@
+﻿using Menu;
+using Steamworks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace BingoMode.BingoMenu
+{
+    internal class BoardControls : PositionedMenuObject
+    {
+        private const float WIDTH = 3f * BUTTON_SIZE + 2f * MARGIN;
+        private const float HEIGHT = BUTTON_SIZE;
+        private const float MARGIN = 5f;
+        private const float BUTTON_SIZE = 30f;
+
+        private SymbolButton filter;
+        private SymbolButton randomize;
+        private SymbolButton shuffle;
+
+        private float anchorX;
+        public float AnchorX
+        {
+            get => anchorX;
+            set
+            {
+                anchorX = value;
+                Vector2 offset = new(Mathf.Lerp(0f, -WIDTH, anchorX), Mathf.Lerp(0f, -HEIGHT, anchorY));
+                filter.pos = offset;
+                randomize.pos = offset + new Vector2(BUTTON_SIZE + MARGIN, 0f);
+                shuffle.pos = offset + new Vector2(2f * BUTTON_SIZE + 2f * MARGIN, 0f);
+            }
+        }
+        private float anchorY;
+        public float AnchorY
+        {
+            get => anchorY;
+            set
+            {
+                anchorY = value;
+                Vector2 offset = new(Mathf.Lerp(0f, -WIDTH, anchorX), Mathf.Lerp(0f, -HEIGHT, anchorY));
+                filter.pos = offset;
+                randomize.pos = offset + new Vector2(BUTTON_SIZE + MARGIN, 0f);
+                shuffle.pos = offset + new Vector2(2f * BUTTON_SIZE + 2f * MARGIN, 0f);
+            }
+        }
+        public bool HostPrivilege
+        {
+            set
+            {
+                filter.buttonBehav.greyedOut = !value;
+                randomize.buttonBehav.greyedOut = !value;
+                shuffle.buttonBehav.greyedOut = !value;
+            }
+        }
+
+        public BoardControls(Menu.Menu menu, MenuObject owner, Vector2 pos, float anchorX = 0f, float anchorY = 0f) : base(menu, owner, pos)
+        {
+            this.anchorX = anchorX;
+            this.anchorY = anchorY;
+            Vector2 offset = new(Mathf.Lerp(0f, -WIDTH, anchorX), Mathf.Lerp(0f, -HEIGHT, anchorY));
+            Vector2 size = Vector2.one * BUTTON_SIZE;
+
+            filter = new(
+                    menu,
+                    this,
+                    "filter",
+                    "FILTER",
+                    offset)
+            { size = size };
+            filter.symbolSprite.scale = 0.8f;
+            filter.roundedRect.size = size;
+            subObjects.Add(filter);
+
+            randomize = new(
+                    menu,
+                    this,
+                    "Sandbox_Randomize",
+                    "RANDOMIZE",
+                    offset + new Vector2(BUTTON_SIZE + MARGIN, 0f))
+            { size = size };
+            randomize.roundedRect.size = size;
+            subObjects.Add(randomize);
+
+            shuffle = new(
+                    menu,
+                    this,
+                    "Menu_Symbol_Shuffle",
+                    "SHUFFLE",
+                    offset + new Vector2(2f * BUTTON_SIZE + 2f * MARGIN, 0f))
+            { size = size };
+            shuffle.roundedRect.size = size;
+            subObjects.Add(shuffle);
+        }
+
+        public override void Singal(MenuObject sender, string message)
+        {
+            if (message == "RANDOMIZE")
+            {
+                BingoHooks.GlobalBoard.GenerateBoard(BingoHooks.GlobalBoard.size, false);
+                menu.PlaySound(SoundID.MENU_Next_Slugcat);
+                return;
+            }
+
+            if (message == "SHUFFLE")
+            {
+                BingoHooks.GlobalBoard.ShuffleBoard();
+                menu.PlaySound(SoundID.MENU_Next_Slugcat);
+                return;
+            }
+
+            if (message == "FILTER")
+            {
+                menu.manager.ShowDialog(new FilterDialog(menu.manager));
+                menu.PlaySound(SoundID.MENU_Button_Standard_Button_Pressed);
+                return;
+            }
+
+            base.Singal(sender, message);
+        }
+    }
+}

--- a/BingoMode/BingoMenu/CreateLobbyDialog.cs
+++ b/BingoMode/BingoMenu/CreateLobbyDialog.cs
@@ -30,13 +30,13 @@ namespace BingoMode.BingoMenu
         private FLabel[] labels;
         private FSprite[] dividers;
         private bool inLobby;
-        private BingoPage owner;
+        private PositionedMenuObject owner;
         private MenuTabWrapper menuTabWrapper;
         private ConfigurableBase maxPlayersConf;
         private OpUpdown maxPlayers;
         private UIelementWrapper maxPlayersWrapper;
 
-        public CreateLobbyDialog(ProcessManager manager, BingoPage owner, bool inLobby = false, bool host = false) : base(manager)
+        public CreateLobbyDialog(ProcessManager manager, PositionedMenuObject owner, bool inLobby = false, bool host = false) : base(manager)
         {
             this.inLobby = inLobby;
             float[] screenOffsets = Custom.GetScreenOffsets();

--- a/BingoMode/BingoMenu/GameControls.cs
+++ b/BingoMode/BingoMenu/GameControls.cs
@@ -1,0 +1,314 @@
+﻿using BepInEx;
+using BingoMode.BingoSteamworks;
+using Expedition;
+using Menu;
+using Menu.Remix;
+using Menu.Remix.MixedUI;
+using Steamworks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using static BingoMode.BingoSteamworks.LobbySettings;
+
+namespace BingoMode.BingoMenu
+{
+    internal class GameControls : PositionedMenuObject
+    {
+        // if you make changes, WIDTH and HEIGHT formulas *might* need to change to reflect that.
+        private const float WIDTH = 2f * RESIZE_BUTTON_SIZE + 2f * MARGIN + UNLOCKS_BUTTON_WIDTH;
+        private const float HEIGHT = START_Y + HOLD_BUTTON_RADIUS * 2f;
+        private const float MARGIN = 5f;
+
+        private const float START_Y = SHELTER_Y + TEXTBOX_HEIGHT + MARGIN;
+        private const float HOLD_BUTTON_RADIUS = 157f / 2f; // not modifiable from here; radius of the biggest circle when focused
+
+        private const float SHELTER_Y = UNLOCKS_Y + UNLOCKS_BUTTON_HEIGHT + MARGIN;
+        private const float TEXTBOX_HEIGHT = 25f; // not modifiable from here
+
+        private const float UNLOCKS_Y = COPY_PASTE_Y + COPY_PASTE_HEIGHT + MARGIN;
+        private const float RESIZE_Y = UNLOCKS_Y + (UNLOCKS_BUTTON_HEIGHT - RESIZE_BUTTON_SIZE) / 2f;
+        private const float RESIZE_BUTTON_SIZE = 40f;
+        private const float UNLOCKS_BUTTON_WIDTH = 150f;
+        private const float UNLOCKS_BUTTON_HEIGHT = 50f;
+
+        private const float COPY_PASTE_Y = 0f;
+        private const float COPY_PASTE_WDITH = 80f;
+        private const float COPY_PASTE_HEIGHT = 20f;
+
+        private MenuTabWrapper tabWrapper;
+        private HoldButton startGame;
+        private MenuLabel shelterLabel;
+        private OpTextBox shelterSetting;
+        private UIelementWrapper shelterSettingWrapper;
+        private OpHoldButton unlocksButton;
+        private UIelementWrapper unlockWrapper;
+        private SymbolButton minusButton;
+        private SymbolButton plusButton;
+        private SimpleButton copyBoard;
+        private SimpleButton pasteBoard;
+
+        private float anchorX;
+        public float AnchorX
+        {
+            get => anchorX;
+            set
+            {
+                anchorX = value;
+                Vector2 offset = new(Mathf.Lerp(0f, -WIDTH, anchorX), Mathf.Lerp(0f, -HEIGHT, anchorY));
+                startGame.pos = offset + new Vector2(WIDTH / 2f, START_Y + HOLD_BUTTON_RADIUS);
+                shelterLabel.pos = offset + new Vector2(RESIZE_BUTTON_SIZE + MARGIN, SHELTER_Y + TEXTBOX_HEIGHT / 2f);
+                shelterSetting.pos = offset + new Vector2(RESIZE_BUTTON_SIZE + MARGIN + shelterLabel.label.textRect.width, SHELTER_Y);
+                unlocksButton.pos = offset + new Vector2(RESIZE_BUTTON_SIZE + MARGIN, UNLOCKS_Y);
+                minusButton.pos = offset + new Vector2(0f, RESIZE_Y);
+                plusButton.pos = offset + new Vector2(RESIZE_BUTTON_SIZE + 2f * MARGIN + UNLOCKS_BUTTON_WIDTH, RESIZE_Y);
+                copyBoard.pos = offset + new Vector2((WIDTH - MARGIN) / 2f - COPY_PASTE_WDITH, 0f);
+                pasteBoard.pos = offset + new Vector2((WIDTH + MARGIN) / 2f, 0f);
+            }
+        }
+        private float anchorY;
+        public float AnchorY
+        {
+            get => anchorY;
+            set
+            {
+                anchorY = value;
+                Vector2 offset = new(Mathf.Lerp(0f, -WIDTH, anchorX), Mathf.Lerp(0f, -HEIGHT, anchorY));
+                startGame.pos = offset + new Vector2(WIDTH / 2f, START_Y + HOLD_BUTTON_RADIUS);
+                shelterLabel.pos = offset + new Vector2(RESIZE_BUTTON_SIZE + MARGIN, SHELTER_Y + TEXTBOX_HEIGHT / 2f);
+                shelterSetting.pos = offset + new Vector2(RESIZE_BUTTON_SIZE + MARGIN + shelterLabel.label.textRect.width, SHELTER_Y);
+                unlocksButton.pos = offset + new Vector2(RESIZE_BUTTON_SIZE + MARGIN, UNLOCKS_Y);
+                minusButton.pos = offset + new Vector2(0f, RESIZE_Y);
+                plusButton.pos = offset + new Vector2(RESIZE_BUTTON_SIZE + 2f * MARGIN + UNLOCKS_BUTTON_WIDTH, RESIZE_Y);
+                copyBoard.pos = offset + new Vector2((WIDTH - MARGIN) / 2f - COPY_PASTE_WDITH, COPY_PASTE_Y);
+                pasteBoard.pos = offset + new Vector2((WIDTH + MARGIN) / 2f, COPY_PASTE_Y);
+            }
+        }
+        public bool HostPrivilege
+        {
+            set
+            {
+                shelterSetting.greyedOut = !value;
+                plusButton.buttonBehav.greyedOut = !value;
+                minusButton.buttonBehav.greyedOut = !value;
+                pasteBoard.buttonBehav.greyedOut = !value;
+                startGame.signalText = value ? "STARTBINGO" : "GETREADY";
+                startGame.menuLabel.text = value ? "BEGIN" : "I'M\nREADY";
+            }
+        }
+
+        public GameControls(Menu.Menu menu, MenuObject owner, Vector2 pos, float anchorX = 0f, float anchorY = 0f) : base(menu, owner, pos)
+        {
+            this.anchorX = anchorX;
+            this.anchorY = anchorY;
+            Vector2 offset = new(Mathf.Lerp(0f, -WIDTH, anchorX), Mathf.Lerp(0f, -HEIGHT, anchorY));
+
+            tabWrapper = new MenuTabWrapper(menu, this);
+            subObjects.Add(tabWrapper);
+
+            startGame = new(
+                    menu,
+                    this,
+                    "BEGIN",
+                    "STARTBINGO",
+                    offset + new Vector2(WIDTH / 2f, START_Y + HOLD_BUTTON_RADIUS),
+                    40f);
+            subObjects.Add(startGame);
+
+            shelterLabel = new MenuLabel(
+                    menu,
+                    this,
+                    "Shelter: ",
+                    offset + new Vector2(RESIZE_BUTTON_SIZE + MARGIN, SHELTER_Y + TEXTBOX_HEIGHT / 2f),
+                    Vector2.zero,
+                    false);
+            shelterLabel.label.alignment = FLabelAlignment.Left;
+            subObjects.Add(shelterLabel);
+            
+            Configurable<string> shelterSettingConf = MenuModList.ModButton.RainWorldDummy.config.Bind("_ShelterSettingBingo", "_", (ConfigAcceptableBase)null);
+            shelterSetting = new(
+                    shelterSettingConf,
+                    offset + new Vector2(RESIZE_BUTTON_SIZE + MARGIN + shelterLabel.label.textRect.width, SHELTER_Y),
+                    UNLOCKS_BUTTON_WIDTH - shelterLabel.label.textRect.width)
+            {
+                alignment = FLabelAlignment.Center,
+                description = "The shelter players start in. Please type in a valid shelter's room name (CASE SENSITIVE), or 'random'",
+                maxLength = 100,
+            };
+            shelterSetting.OnValueUpdate += ShelterSetting_OnValueUpdate;
+            shelterSettingWrapper = new UIelementWrapper(tabWrapper, shelterSetting);
+            shelterSetting.value = "random";
+
+            unlocksButton = new(
+                    offset + new Vector2(RESIZE_BUTTON_SIZE + MARGIN, UNLOCKS_Y),
+                    new Vector2(UNLOCKS_BUTTON_WIDTH, UNLOCKS_BUTTON_HEIGHT),
+                    menu.Translate("CONFIGURE<LINE>PERKS & BURDENS").Replace("<LINE>", "\r\n"),
+                    20f)
+            { description = " " };
+            unlocksButton.OnPressDone += UnlocksButton_OnPressDone;
+            unlockWrapper = new UIelementWrapper(tabWrapper, unlocksButton);
+
+            Vector2 resizeButtonSize = new(RESIZE_BUTTON_SIZE, RESIZE_BUTTON_SIZE);
+            minusButton = new(
+                    menu,
+                    this,
+                    "minus",
+                    "REMOVESIZE",
+                    offset + new Vector2(0f, RESIZE_Y))
+            { size = resizeButtonSize };
+            minusButton.roundedRect.size = resizeButtonSize;
+            subObjects.Add(minusButton);
+
+            plusButton = new(
+                    menu,
+                    this,
+                    "plus",
+                    "ADDSIZE",
+                    offset + new Vector2(RESIZE_BUTTON_SIZE + 2f * MARGIN + UNLOCKS_BUTTON_WIDTH, RESIZE_Y))
+            { size = resizeButtonSize };
+            plusButton.roundedRect.size = resizeButtonSize;
+            subObjects.Add(plusButton);
+
+            copyBoard = new(
+                    menu,
+                    this,
+                    "Copy board",
+                    "COPYTOCLIPBOARD",
+                    offset + new Vector2((WIDTH - MARGIN) / 2f - COPY_PASTE_WDITH, COPY_PASTE_Y),
+                    new Vector2(COPY_PASTE_WDITH, COPY_PASTE_HEIGHT));
+            subObjects.Add(copyBoard);
+
+            pasteBoard = new(
+                    menu,
+                    this,
+                    "Paste board",
+                    "PASTEFROMCLIPBOARD",
+                    offset + new Vector2((WIDTH + MARGIN) / 2f, COPY_PASTE_Y),
+                    new Vector2(COPY_PASTE_WDITH, COPY_PASTE_HEIGHT));
+            subObjects.Add(pasteBoard);
+
+        }
+
+        public override void Singal(MenuObject sender, string message)
+        {
+            if (message == "GETREADY")
+            {
+                SteamMatchmaking.SetLobbyMemberData(SteamTest.CurrentLobby, "ready", "1");
+                startGame.signalText = "GETUNREADY";
+                startGame.menuLabel.text = "I'M NOT\nREADY";
+                menu.PlaySound(SoundID.MENU_Start_New_Game);
+            }
+
+            if (message == "GETUNREADY")
+            {
+                SteamMatchmaking.SetLobbyMemberData(SteamTest.CurrentLobby, "ready", "0");
+                startGame.signalText = "GETREADY";
+                startGame.menuLabel.text = "I'M\nREADY";
+                menu.PlaySound(SoundID.MENU_Start_New_Game);
+            }
+
+            if (message == "ADDSIZE")
+            {
+                if (BingoHooks.GlobalBoard.size < 9)
+                {
+                    BingoHooks.GlobalBoard.GenerateBoard(++BingoHooks.GlobalBoard.size, true);
+                    menu.PlaySound(SoundID.MENU_Next_Slugcat);
+                }
+                return;
+            }
+
+            if (message == "REMOVESIZE")
+            {
+                if (BingoHooks.GlobalBoard.size > 1)
+                {
+                    BingoHooks.GlobalBoard.GenerateBoard(--BingoHooks.GlobalBoard.size, true);
+                    menu.PlaySound(SoundID.MENU_Next_Slugcat);
+                }
+                return;
+            }
+
+            if (message == "COPYTOCLIPBOARD")
+            {
+                UniClipboard.SetText(BingoHooks.GlobalBoard.ToString());
+                return;
+            }
+
+            if (message == "PASTEFROMCLIPBOARD")
+            {
+                BingoHooks.GlobalBoard.FromString(UniClipboard.GetText());
+                SteamTest.UpdateOnlineBingo();
+                return;
+            }
+
+            base.Singal(sender, message);
+        }
+
+        public override void RemoveSprites()
+        {
+            base.RemoveSprites();
+
+            unlocksButton.Unload();
+            shelterSetting.Unload();
+            shelterSetting.OnValueUpdate -= ShelterSetting_OnValueUpdate;
+            tabWrapper.wrappers.Remove(unlocksButton);
+            tabWrapper.wrappers.Remove(shelterSetting);
+            tabWrapper.subObjects.Remove(unlockWrapper);
+            tabWrapper.subObjects.Remove(shelterSettingWrapper);
+            foreach (MenuObject obj in subObjects)
+            {
+                obj.RemoveSprites();
+                RecursiveRemoveSelectables(obj);
+            }
+            subObjects.Clear();
+        }
+
+        private void UnlocksButton_OnPressDone(UIfocusable trigger)
+        {
+            UnlockDialog unlockDialog = new(menu.manager, (menu as ExpeditionMenu).challengeSelect);
+            unlocksButton.greyedOut = true;
+            unlocksButton.Reset();
+            if (BingoData.MultiplayerGame)
+            {
+                bool isHost = SteamMatchmaking.GetLobbyOwner(SteamTest.CurrentLobby) == SteamTest.selfIdentity.GetSteamID();
+                foreach (var perk in unlockDialog.perkButtons)
+                {
+                    perk.buttonBehav.greyedOut = perk.buttonBehav.greyedOut || BingoData.globalSettings.perks == AllowUnlocks.None || (BingoData.globalSettings.perks == AllowUnlocks.Inherited && !isHost);
+                }
+                foreach (var burden in unlockDialog.burdenButtons)
+                {
+                    burden.buttonBehav.greyedOut = burden.buttonBehav.greyedOut || BingoData.globalSettings.burdens == AllowUnlocks.None || (BingoData.globalSettings.burdens == AllowUnlocks.Inherited && !isHost);
+                }
+            }
+            string[] bannedBurdens = ["bur-doomed"];
+            string[] bannedPerks = ["unl-passage", "unl-karma"];
+            foreach (var bur in unlockDialog.burdenButtons)
+            {
+                if (bannedBurdens.Contains(bur.signalText))
+                {
+                    bur.buttonBehav.greyedOut = true;
+                    if (ExpeditionGame.activeUnlocks.Contains(bur.signalText)) unlockDialog.ToggleBurden(bur.signalText);
+                }
+            }
+            foreach (var per in unlockDialog.perkButtons)
+            {
+                if (bannedPerks.Contains(per.signalText))
+                {
+                    per.buttonBehav.greyedOut = true;
+                    if (ExpeditionGame.activeUnlocks.Contains(per.signalText)) unlockDialog.ToggleBurden(per.signalText);
+                }
+            }
+            menu.manager.ShowDialog(unlockDialog);
+        }
+
+        public void UnlocksDialogClose()
+        {
+            unlocksButton.greyedOut = false;
+            unlocksButton.Reset();
+        }
+
+        private void ShelterSetting_OnValueUpdate(UIconfig config, string value, string oldValue) =>
+            BingoData.BingoDen = value.IsNullOrWhiteSpace() ? "random" : value;
+    }
+}

--- a/BingoMode/BingoMenu/LobbyInfo.cs
+++ b/BingoMode/BingoMenu/LobbyInfo.cs
@@ -1,0 +1,181 @@
+﻿using BingoMode.BingoSteamworks;
+using Menu;
+using UnityEngine;
+using static BingoMode.BingoSteamworks.LobbySettings;
+
+namespace BingoMode.BingoMenu
+{
+    public class LobbyInfo : PositionedMenuObject
+    {
+        private const float MARGIN = 5f;
+        private const float ALPHA_THRESHOLD = 0.01f;
+
+        private MenuLabel nameLabel;
+        private MenuLabel playerLabel;
+        private SimpleButton button;
+        private InfoPanel infoPanel;
+
+        private float _alpha = 1f;
+
+        public Vector2 size;
+        public float Alpha
+        {
+            get => _alpha;
+            set
+            {
+                if (_alpha == value)
+                    return;
+
+                nameLabel.label.alpha = value;
+                playerLabel.label.alpha = value;
+
+                button.buttonBehav.greyedOut = value < ALPHA_THRESHOLD;
+
+                _alpha = value;
+            }
+        }
+
+        public LobbyInfo(Menu.Menu menu, MenuObject owner, Vector2 pos, Vector2 size, LobbyData data) : base(menu, owner, pos)
+        {
+            this.size = size;
+
+            nameLabel = new(menu, this, data.name, new Vector2(MARGIN, size.y / 2f), Vector2.zero, false);
+            nameLabel.label.alignment = FLabelAlignment.Left;
+            nameLabel.label.anchorY = 0.5f;
+            subObjects.Add(nameLabel);
+
+            playerLabel = new(menu, this, $"{data.currentPlayers}/{data.maxPlayers}", new Vector2(size.x - MARGIN, size.y / 2f), Vector2.zero, false);
+            playerLabel.label.alignment = FLabelAlignment.Right;
+            playerLabel.label.anchorY = 0.5f;
+            subObjects.Add(playerLabel);
+
+            button = new(menu, this, "", "JOIN-" + data.lobbyID.ToString(), Vector2.zero, size);
+            foreach (FSprite sprite in button.roundedRect.sprites)
+                sprite.alpha = 0f;
+            subObjects.Add(button);
+
+            infoPanel = new(menu, this, new Vector2(size.x + MARGIN, (size.y / 2f) - (InfoPanel.HEIGHT / 2f)), data);
+            subObjects.Add(infoPanel);
+        }
+
+        public override void GrafUpdate(float timeStacker)
+        {
+            button.roundedRect.fillAlpha = 0f;
+            base.GrafUpdate(timeStacker);
+            infoPanel.Visible = button.IsMouseOverMe && _alpha >= ALPHA_THRESHOLD;
+        }
+
+        public override void RemoveSprites()
+        {
+            base.RemoveSprites();
+            //infoPanel.Visible = true;
+            foreach (MenuObject obj in subObjects)
+            {
+                obj.RemoveSprites();
+                RecursiveRemoveSelectables(obj);
+            }
+            subObjects.Clear();
+        }
+
+        private class InfoPanel : PositionedMenuObject
+        {
+            public const float WIDTH = 180f;
+            public const float HEIGHT = 100f;
+            private const float BORDER_WIDTH = 2f;
+            private const float POLICE_SIZE = 15f; // not actually modifiable from here
+
+            private bool _visible = true;
+
+            private FSprite background;
+            private FSprite[] border;
+            private MenuLabel[] labels;
+
+            public bool Visible
+            {
+                get => _visible;
+                set
+                {
+                    if (_visible == value)
+                        return;
+                    background.isVisible = value;
+                    foreach (FSprite line in border)
+                        line.isVisible = value;
+                    foreach (MenuLabel label in labels)
+                        label.label.isVisible = value;
+                    _visible = value;
+                }
+            }
+
+            public InfoPanel(Menu.Menu menu, MenuObject owner, Vector2 pos, LobbyData data) : base(menu, owner, pos)
+            {
+                background = new FSprite("pixel")
+                {
+                    scaleX = WIDTH,
+                    scaleY = HEIGHT,
+                    anchorX = 0f,
+                    anchorY = 0f,
+                    color = Color.black,
+                    alpha = 0.9f
+                };
+                Container.AddChild(background);
+
+                border = new FSprite[4];
+                for (int i = 0; i < 4; i++)
+                {
+                    border[i] = new FSprite("pixel")
+                    {
+                        anchorX = (i < 2) ? 0f : 1f,
+                        anchorY = (i < 2) ? 0f : 1f,
+                        scaleX = (i % 2 == 0) ? WIDTH : BORDER_WIDTH,
+                        scaleY = (i % 2 == 0) ? BORDER_WIDTH : HEIGHT,
+                        shader = page.menu.manager.rainWorld.Shaders["MenuText"]
+                    };
+                    Container.AddChild(border[i]);
+                }
+
+                labels = new MenuLabel[6];
+                Vector2 labelPos = new(WIDTH / 2f, HEIGHT / (labels.Length + 1f) - POLICE_SIZE / 2f);
+                for (int i = 0; i < labels.Length; i++)
+                {
+                    labels[i] = new(menu, this, "", labelPos, Vector2.zero, false);
+                    labels[i].label.shader = page.menu.manager.rainWorld.Shaders["MenuText"];
+                    labels[i].label.anchorX = 0f;
+                    labels[i].label.anchorY = 0f;
+                    labels[i].label.alignment = FLabelAlignment.Center;
+                    subObjects.Add(labels[i]);
+                    labelPos += Vector2.up * HEIGHT / (labels.Length + 1f);
+                }
+
+                labels[0].text = "Game mode: " + data.gameMode;
+                labels[1].text = "Mod version: " + data.version;
+                labels[2].text = "Perks: " + (data.perks == AllowUnlocks.Any ? "Allowed" : data.perks == AllowUnlocks.None ? "Disabled" : "Host decides");
+                labels[3].text = "Burdens: " + (data.burdens == AllowUnlocks.Any ? "Allowed" : data.burdens == AllowUnlocks.None ? "Disabled" : "Host decides");
+                labels[4].text = "Require host's mods: " + (data.hostMods ? "Yes" : "No");
+                labels[5].text = "Slugcat: " + SlugcatStats.getSlugcatName(new(data.slugcat));
+            }
+
+            public override void GrafUpdate(float timeStacker)
+            {
+                base.GrafUpdate(timeStacker);
+
+                background.SetPosition(DrawPos(timeStacker));
+                for (int i = 0; i < 4; i++)
+                    border[i].SetPosition(DrawPos(timeStacker) + (i < 2 ? Vector2.zero : new Vector2(WIDTH, HEIGHT)));
+            }
+
+            public override void RemoveSprites()
+            {
+                base.RemoveSprites();
+                foreach (MenuObject obj in subObjects)
+                {
+                    obj.RemoveSprites();
+                    RecursiveRemoveSelectables(obj);
+                }
+                subObjects.Clear();
+                background.RemoveFromContainer();
+                foreach (FSprite line in border)
+                    line.RemoveFromContainer();
+            }
+        }
+    }
+}

--- a/BingoMode/BingoMenu/MultiplayerPanel.cs
+++ b/BingoMode/BingoMenu/MultiplayerPanel.cs
@@ -1,0 +1,561 @@
+﻿using BingoMode.BingoRandomizer;
+using BingoMode.BingoSteamworks;
+using Expedition;
+using Menu;
+using Menu.Remix;
+using Menu.Remix.MixedUI;
+using Steamworks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Principal;
+using UnityEngine;
+using static BingoMode.BingoSteamworks.LobbySettings;
+
+namespace BingoMode.BingoMenu
+{
+    internal class MultiplayerPanel : PositionedMenuObject
+    {
+        private const float MARGIN = 7f;
+        private const float TEXT_BUTTON_HEIGHT = 25f; // only partially changes stuff, change not recommended
+        private const float BIG_TEXT_HEIGHT = 30f; // not actually modifiable from here
+        private const float SYMBOL_BUTTON_SIZE = 35f;
+        private const float REFRESH_SEARCH_WIDTH = 60f;
+        private const float FRIENDS_WIDTH = 110f;
+        private const float DIVIDER_WIDTH = 2f;
+        private const float HEADER_HEIGHT = 2f * MARGIN + SYMBOL_BUTTON_SIZE + DIVIDER_WIDTH;
+
+        private const float LOBBY_HEIGHT = 20f;
+        private const float LOBBY_SPACING = 5f;
+        private const float PLAYER_HEIGHT = LOBBY_HEIGHT;
+        private const float PLAYER_SPACING = LOBBY_SPACING;
+        private const float SLIDER_WIDTH = 10f;
+        private const float SLIDER_OFFSET = 15f; // not actually modifiable from here
+        private const float SLIDER_DEAD_ZONE = 21f; // not actually modifiable from here
+        private const float DIV_X_OFFSET = 2f;
+
+        private bool inLobby = false;
+
+        private RoundedRect background;
+
+        private MenuTabWrapper tabWrapper;
+        private UIelementWrapper nameFilterWrapper;
+        private OpTextBox nameFilter;
+        private SimpleButton refreshSearch;
+        private SimpleButton friendsOnly;
+        private SymbolButton createLobby;
+
+        private MenuLabel lobbyName;
+        private SymbolButton lobbySettings;
+
+        private FSprite divider;
+        private VerticalSlider slider;
+
+        private List<LobbyInfo> foundLobbies = [];
+        public List<PlayerInfo> lobbyPlayers = [];
+        private List<FSprite> lobbyDividers = [];
+
+        private bool _visible = true;
+        
+        public Vector2 size;
+        public float sliderF;
+        public bool Visible
+        {
+            get => _visible;
+            set
+            {
+                if (value == _visible)
+                    return;
+
+                if (!value)
+                {
+                    RemoveLobbiesSprites();
+                    RemovePlayersSprites();
+                }
+
+                _visible = value;
+            }
+        }
+        public bool InLobby { get => inLobby; }
+
+        public MultiplayerPanel(Menu.Menu menu, MenuObject owner, Vector2 pos, Vector2 size) : base(menu, owner, pos)
+        {
+            this.size = size;
+
+            background = new RoundedRect(menu, this, Vector2.zero, size, true);
+            subObjects.Add(background);
+
+            tabWrapper = new(menu, this);
+            subObjects.Add(tabWrapper);
+
+            ConstructSearchHeader();
+
+            divider = new("pixel")
+            {
+                scaleX = size.x,
+                scaleY = DIVIDER_WIDTH,
+                anchorX = 0f,
+                anchorY = 0f,
+                x = pos.x,
+                y = pos.y + size.y - HEADER_HEIGHT
+            };
+            Container.AddChild(divider);
+
+            slider = new(
+                    menu,
+                    this,
+                    "",
+                    new Vector2(size.x - MARGIN - SLIDER_OFFSET - SLIDER_WIDTH / 2f, MARGIN),
+                    new Vector2(SLIDER_WIDTH, size.y - HEADER_HEIGHT - 2 * MARGIN - SLIDER_DEAD_ZONE),
+                    BingoEnums.MultiplayerSlider,
+                    true);
+            sliderF = 1f;
+            subObjects.Add(slider);
+        }
+
+        public override void GrafUpdate(float timeStacker)
+        {
+            base.GrafUpdate(timeStacker);
+
+            divider.SetPosition(DrawPos(timeStacker) + new Vector2(0f, size.y - HEADER_HEIGHT));
+
+            if (!inLobby)
+                DrawDisplayedLobbies(timeStacker);
+            else
+                DrawPlayerInfo(timeStacker);
+        }
+
+        public override void Singal(MenuObject sender, string message)
+        {
+            if (message == "REFRESH_SEARCH")
+            {
+                RemoveLobbiesSprites();
+                SteamTest.GetJoinableLobbies();
+                return;
+            }
+
+            if (message == "TOGGLE_FRIENDSONLY")
+            {
+                SteamTest.CurrentFilters.friendsOnly = !SteamTest.CurrentFilters.friendsOnly;
+                friendsOnly.menuLabel.text = SteamTest.CurrentFilters.friendsOnly ? "Friends only: Yes" : "Friends only: No";
+                return;
+            }
+
+            if (message == "CREATE_LOBBY")
+            {
+                menu.manager.ShowDialog(new CreateLobbyDialog(menu.manager, this));
+                return;
+            }
+
+            if (message == "CHANGE_SETTINGS")
+            {
+                menu.manager.ShowDialog(new CreateLobbyDialog(menu.manager, this, true, true));
+                return;
+            }
+
+            if (message == "INFO_SETTINGS")
+            {
+                menu.manager.ShowDialog(new CreateLobbyDialog(menu.manager, this, true, false));
+                return;
+            }
+
+            if (message.StartsWith("JOIN-"))
+            {
+                if (SteamTest.CurrentLobby != default)
+                    return;
+
+                (sender as SimpleButton).buttonBehav.greyedOut = true;
+
+                if (ulong.TryParse(message.Split('-')[1], out ulong lobbyID))
+                {
+                    CSteamID lobby = new(lobbyID);
+                    if (!SteamTest.JoinLobby(lobby, menu.manager, out string errMsg, out bool tryReconnect))
+                    {
+                        if (tryReconnect)
+                            menu.manager.ShowDialog(new InfoDialog(menu.manager, errMsg, lobby));
+                        else
+                            menu.manager.ShowDialog(new InfoDialog(menu.manager, errMsg));
+                    }
+                }
+                else
+                {
+                    Plugin.logger.LogError("FAILED TO PARSE LOBBY ULONG FROM " + message);
+                    (sender as SimpleButton).buttonBehav.greyedOut = false;
+                }
+                return;
+            }
+
+            if (message.StartsWith("KICK-"))
+            {
+                ulong playerId = ulong.Parse(message.Split('-')[1], System.Globalization.NumberStyles.Any);
+                SteamNetworkingIdentity kickedPlayer = new SteamNetworkingIdentity();
+                kickedPlayer.SetSteamID64(playerId);
+                InnerWorkings.SendMessage("@", kickedPlayer);
+                return;
+            }
+            
+            if (message == "FOCUS_DD")
+            {
+                foreach (PlayerInfo player in lobbyPlayers)
+                {
+                    if (player != sender)
+                    {
+                        player.DropDownEnabled = false;
+                    }
+                }
+                return;
+            }
+
+            if (message == "UNFOCUS_DD")
+            {
+                foreach (PlayerInfo player in lobbyPlayers)
+                {
+                    if (player != sender)
+                        player.DropDownEnabled = true;
+                }
+                return;
+            }
+            
+            if (message.StartsWith("SWTEAM-"))
+            {
+                string[] data = message.Split('-');
+                ulong playerId = ulong.Parse(data[1], System.Globalization.NumberStyles.Any);
+                int playerTeam = int.Parse(data[2], System.Globalization.NumberStyles.Any);
+                if (playerId == SteamTest.selfIdentity.GetSteamID64())
+                {
+                    SteamTest.team = playerTeam;
+                    SteamMatchmaking.SetLobbyMemberData(SteamTest.CurrentLobby, "playerTeam", playerTeam.ToString());
+                    return;
+                }
+                SteamNetworkingIdentity playerIdentity = new();
+                playerIdentity.SetSteamID64(playerId);
+                InnerWorkings.SendMessage("%" + playerTeam, playerIdentity);
+                return;
+            }
+
+            base.Singal(sender, message);
+        }
+
+        public override void RemoveSprites()
+        {
+            base.RemoveSprites();
+            foreach (MenuObject obj in subObjects)
+            {
+                obj.RemoveSprites();
+                RecursiveRemoveSelectables(obj);
+            }
+            subObjects.Clear();
+            divider.RemoveFromContainer();
+            foreach (FSprite divider in lobbyDividers)
+                divider.RemoveFromContainer();
+        }
+
+        public void SwitchToLobby(bool create)
+        {
+            if (inLobby)
+                return;
+            inLobby = true;
+            if (BingoData.globalSettings.perks == AllowUnlocks.None)
+                ExpeditionGame.activeUnlocks.RemoveAll(x => x.StartsWith("unl-"));
+            if (BingoData.globalSettings.burdens == AllowUnlocks.None)
+                ExpeditionGame.activeUnlocks.RemoveAll(x => x.StartsWith("bur-"));
+
+            DestructSearchHeader();
+            RemoveLobbiesSprites();
+
+            ConstructLobbyHeader();
+            CreateLobbyPlayers();
+
+        }
+
+        public void SwitchToSearch()
+        {
+            if (!inLobby)
+                return;
+            inLobby = false;
+            DestructLobbyHeader();
+            RemovePlayersSprites();
+
+            ConstructSearchHeader();
+            CreateDisplayedLobbies();
+        }
+
+        /// <summary>
+        /// Refresh lobbies list with the given list of steam IDs.
+        /// </summary>
+        /// <param name="lobbies">A list of steam IDs from which to fetch lobby data.</param>
+        public void AddLobbies(List<CSteamID> lobbies)
+        {
+            RemoveLobbiesSprites();
+            Vector2 lobbySize = new(size.x - 3f * MARGIN - SLIDER_WIDTH, LOBBY_HEIGHT);
+            foreach (var lobby in lobbies)
+            {
+                try
+                {
+                    LobbyData data = SteamTest.GetLobbyData(lobby);
+                    foundLobbies.Add(new LobbyInfo(menu, this, Vector2.zero, lobbySize, data));
+                }
+                catch (Exception e)
+                {
+                    Plugin.logger.LogError("Failed to get lobby info from lobby " + lobby + ". Exception:\n" + e);
+                }
+            }
+            CreateDisplayedLobbies();
+        }
+
+        public void UpdateLobbyHost(bool isHost)
+        {
+            lobbySettings.UpdateSymbol(isHost ? "settingscog" : "Menu_InfoI");
+            lobbySettings.signalText = isHost ? "CHANGE_SETTINGS" : "INFO_SETTINGS";
+        }
+
+        public void ResetPlayerLobby()
+        {
+            RemovePlayersSprites();
+            CreateLobbyPlayers();
+        }
+
+        private void ConstructSearchHeader()
+        {
+            float smallItemY = size.y - MARGIN - SYMBOL_BUTTON_SIZE + (SYMBOL_BUTTON_SIZE - TEXT_BUTTON_HEIGHT) / 2f;
+
+            Configurable<string> nameFilterConf = MenuModList.ModButton.RainWorldDummy.config.Bind("_NameFilterBingo", "", (ConfigAcceptableBase)null);
+            nameFilter = new(
+                    nameFilterConf,
+                    new Vector2(MARGIN, smallItemY),
+                    size.x - 5 * MARGIN - REFRESH_SEARCH_WIDTH - FRIENDS_WIDTH - SYMBOL_BUTTON_SIZE)
+            { allowSpace = true };
+            nameFilter.OnValueUpdate += NameFilter_OnValueUpdate;
+            nameFilterWrapper = new(tabWrapper, nameFilter);
+
+            refreshSearch = new(
+                    menu,
+                    this,
+                    "Refresh",
+                    "REFRESH_SEARCH",
+                    new Vector2(size.x - 3f * MARGIN - REFRESH_SEARCH_WIDTH - FRIENDS_WIDTH - SYMBOL_BUTTON_SIZE, smallItemY),
+                    new Vector2(REFRESH_SEARCH_WIDTH, TEXT_BUTTON_HEIGHT));
+            subObjects.Add(refreshSearch);
+
+            friendsOnly = new(
+                    menu,
+                    this,
+                    "Friends only: No",
+                    "TOGGLE_FRIENDSONLY",
+                    new Vector2(size.x - 2f * MARGIN - FRIENDS_WIDTH - SYMBOL_BUTTON_SIZE, smallItemY),
+                    new Vector2(FRIENDS_WIDTH, TEXT_BUTTON_HEIGHT));
+            subObjects.Add(friendsOnly);
+
+            createLobby = new(
+                    menu,
+                    this,
+                    "plus",
+                    "CREATE_LOBBY",
+                    new Vector2(size.x - MARGIN - SYMBOL_BUTTON_SIZE, size.y - MARGIN - SYMBOL_BUTTON_SIZE))
+            { size = Vector2.one * SYMBOL_BUTTON_SIZE };
+            createLobby.roundedRect.size = createLobby.size;
+            createLobby.symbolSprite.scale = 0.9f;
+            subObjects.Add(createLobby);
+
+        }
+
+        private void DestructSearchHeader()
+        {
+            nameFilter.OnValueUpdate -= NameFilter_OnValueUpdate;
+            nameFilter.Unload();
+            nameFilterWrapper.RemoveSprites();
+            RecursiveRemoveSelectables(nameFilterWrapper);
+            nameFilterWrapper = null;
+
+            refreshSearch.RemoveSprites();
+            RecursiveRemoveSelectables(refreshSearch);
+            subObjects.Remove(refreshSearch);
+            refreshSearch = null;
+
+            friendsOnly.RemoveSprites();
+            RecursiveRemoveSelectables(friendsOnly);
+            subObjects.Remove(friendsOnly);
+            friendsOnly = null;
+
+            createLobby.RemoveSprites();
+            RecursiveRemoveSelectables(createLobby);
+            subObjects.Remove(createLobby);
+            createLobby = null;
+        }
+
+        private void ConstructLobbyHeader()
+        {
+            lobbyName = new MenuLabel(
+                    menu,
+                    this,
+                    SteamMatchmaking.GetLobbyData(SteamTest.CurrentLobby, "name"),
+                    new Vector2(MARGIN, size.y - MARGIN - BIG_TEXT_HEIGHT),
+                    new Vector2(size.x - 3f * MARGIN - SYMBOL_BUTTON_SIZE, BIG_TEXT_HEIGHT),
+                    true);
+            subObjects.Add(lobbyName);
+
+            bool isHost = SteamMatchmaking.GetLobbyOwner(SteamTest.CurrentLobby) == SteamTest.selfIdentity.GetSteamID();
+            lobbySettings = new(
+                    menu,
+                    this,
+                    isHost ? "settingscog" : "Menu_InfoI",
+                    isHost ? "CHANGE_SETTINGS" : "INFO_SETTINGS",
+                    new Vector2(size.x - MARGIN - SYMBOL_BUTTON_SIZE, size.y - MARGIN - SYMBOL_BUTTON_SIZE))
+            { size = Vector2.one * SYMBOL_BUTTON_SIZE };
+            lobbySettings.roundedRect.size = lobbySettings.size;
+            lobbySettings.symbolSprite.scale = 0.9f;
+            subObjects.Add(lobbySettings);
+        }
+
+        private void DestructLobbyHeader()
+        {
+            lobbyName.RemoveSprites();
+            RecursiveRemoveSelectables(lobbyName);
+            subObjects.Remove(lobbyName);
+            lobbyName = null;
+
+            lobbySettings.RemoveSprites();
+            RecursiveRemoveSelectables(lobbySettings);
+            subObjects.Remove(lobbySettings);
+            lobbySettings = null;
+        }
+
+        private void NameFilter_OnValueUpdate(UIconfig config, string value, string oldValue)
+        {
+            SteamTest.CurrentFilters.text = value;
+            SteamTest.GetJoinableLobbies();
+        }
+
+        private void CreateDisplayedLobbies()
+        {
+            foreach (LobbyInfo lobby in foundLobbies)
+                subObjects.Add(lobby);
+            for (int i = 0; i < foundLobbies.Count - 1; i++)
+            {
+                FSprite divider = new("pixel")
+                {
+                    scaleX = size.x - 3f * MARGIN - SLIDER_WIDTH - 2f * DIV_X_OFFSET,
+                    scaleY = 1f,
+                    anchorX = 0f
+                };
+                lobbyDividers.Add(divider);
+                Container.AddChild(divider);
+            }
+    }
+
+        private void RemoveLobbiesSprites()
+        {
+            foreach (LobbyInfo lobby in foundLobbies)
+            {
+                lobby.RemoveSprites();
+                subObjects.Remove(lobby);
+            }
+            foundLobbies.Clear();
+
+            foreach (FSprite divider in lobbyDividers)
+                divider.RemoveFromContainer();
+            lobbyDividers.Clear();
+        }
+
+        private void CreateLobbyPlayers()
+        {
+            bool isHost = SteamMatchmaking.GetLobbyOwner(SteamTest.CurrentLobby) == SteamTest.selfIdentity.GetSteamID();
+            Vector2 playerSize = new(size.x - 3f * MARGIN - SLIDER_WIDTH, PLAYER_HEIGHT);
+
+            BingoData.MultiplayerGame = true;
+            List<PlayerData> players = SteamTest.GetPlayersData();
+
+            // Build the list backwards because z-indexing doesn't exist in these lands. yippee...
+            players.Reverse();
+            foreach (PlayerData player in players)
+            {
+                PlayerInfo info = new(menu, this, Vector2.zero, playerSize, isHost, player);
+                lobbyPlayers.Insert(0, info);
+                subObjects.Add(info);
+            }
+
+            if (lobbyPlayers.Count == 0)
+                Plugin.logger.LogMessage("No people in the lobby");
+
+            for (int i = 0; i < lobbyPlayers.Count - 1; i++)
+            {
+                FSprite divider = new("LinearGradient200")
+                {
+                    rotation = 90f,
+                    anchorY = 0f,
+                    scaleY = 1.5f
+                };
+                lobbyDividers.Add(divider);
+                Container.AddChild(divider);
+            }
+        }
+
+        private void RemovePlayersSprites()
+        {
+            foreach (PlayerInfo player in lobbyPlayers)
+            {
+                player.RemoveSprites();
+                RecursiveRemoveSelectables(player);
+                subObjects.Remove(player);
+            }
+            lobbyPlayers.Clear();
+
+            foreach (FSprite divider in lobbyDividers)
+                divider.RemoveFromContainer();
+            lobbyDividers.Clear();
+        }
+
+        private void DrawDisplayedLobbies(float timeStacker)
+        {
+            // top and bottom require a slight offset, otherwise dividers land in-between pixels and disappear. Yes, that is stupid.
+            float top = size.y - HEADER_HEIGHT - MARGIN - LOBBY_HEIGHT + 0.01f;
+            float bottom = MARGIN - 0.01f;
+            float middle = bottom + (top - bottom) / 2f;
+            float list_height = (foundLobbies.Count - 1) * (LOBBY_HEIGHT + LOBBY_SPACING);
+            float y = (list_height > top - bottom) ? Mathf.Lerp(list_height + bottom, top, sliderF) : top;
+
+            foreach (LobbyInfo lobby in foundLobbies)
+            {
+                float overshoot = (y > middle) ? (y - top) / MARGIN : (bottom - y) / MARGIN;
+                lobby.Alpha = Mathf.Lerp(1f, 0f, overshoot);
+                lobby.pos = new Vector2(MARGIN, y);
+                y -= LOBBY_HEIGHT + LOBBY_SPACING;
+            }
+
+            y = (list_height > top - bottom) ? Mathf.Lerp(list_height + bottom, top, sliderF) : top;
+            foreach (FSprite divider in lobbyDividers)
+            {
+                float overshoot = (y > middle) ? (y - top) / MARGIN : (bottom - y + LOBBY_HEIGHT + LOBBY_SPACING) / MARGIN;
+                divider.alpha = Mathf.Lerp(1f, 0f, overshoot);
+                divider.SetPosition(DrawPos(timeStacker) + new Vector2(MARGIN + DIV_X_OFFSET, y - LOBBY_SPACING / 2f));
+                y -= LOBBY_HEIGHT + LOBBY_SPACING;
+            }
+        }
+
+        private void DrawPlayerInfo(float timeStacker)
+        {
+            // top and bottom require a slight offset, otherwise dividers land in-between pixels and disappear. Yes, that is stupid.
+            float top = size.y - HEADER_HEIGHT - MARGIN - PLAYER_HEIGHT + 0.01f;
+            float bottom = MARGIN - 0.01f;
+            float middle = bottom + (top - bottom) / 2f;
+            float list_height = (lobbyPlayers.Count - 1) * (PLAYER_HEIGHT + PLAYER_SPACING);
+            float y = (list_height > top - bottom) ? Mathf.Lerp(list_height + bottom, top, sliderF) : top;
+            foreach (PlayerInfo player in lobbyPlayers)
+            {
+                float overshoot = (y > middle) ? (y - top) / MARGIN : (bottom - y) / MARGIN;
+                player.Alpha = Mathf.Lerp(1f, 0f, overshoot);
+                player.pos = new Vector2(MARGIN, y);
+                y -= PLAYER_HEIGHT + PLAYER_SPACING;
+            }
+
+            y = (list_height > top - bottom) ? Mathf.Lerp(list_height + bottom, top, sliderF) : top;
+            foreach (FSprite divider in lobbyDividers)
+            {
+                float overshoot = (y > middle) ? (y - top) / MARGIN : (bottom - y + PLAYER_HEIGHT + PLAYER_SPACING) / MARGIN;
+                divider.alpha = Mathf.Lerp(1f, 0f, overshoot);
+                divider.SetPosition(DrawPos(timeStacker) + new Vector2(MARGIN + DIV_X_OFFSET, y - PLAYER_SPACING / 2f));
+                y -= PLAYER_HEIGHT + PLAYER_SPACING;
+            }
+        }
+    }
+}

--- a/BingoMode/BingoMenu/PlayerInfo.cs
+++ b/BingoMode/BingoMenu/PlayerInfo.cs
@@ -1,0 +1,160 @@
+﻿using BingoMode.BingoSteamworks;
+using Menu;
+using Menu.Remix;
+using Menu.Remix.MixedUI;
+using System.Security.Principal;
+using UnityEngine;
+
+namespace BingoMode.BingoMenu
+{
+    public class PlayerInfo : PositionedMenuObject
+    {
+        private const float MARGIN = 5f;
+        private const float READY_MARK_SIZE = 5f;
+        private const float ALPHA_THRESHOLD = 0.01f;
+        private const float SELECT_TEAM_WIDTH = 90f;
+        private const float KICK_WIDTH = 40f;
+        private const float DROPDOWN_SIZE = 300f; // can be arbitrarily large, it just needs to be bigger than the dropdown.
+
+        private float _alpha = 1f;
+        private PlayerData data;
+
+        private FSprite readyMark;
+        private MenuLabel nameLabel;
+        private SimpleButton kick;
+        private MenuTabWrapper tabWrapper;
+        private UIelementWrapper selectTeamWrapper;
+        private OpComboBox selectTeam;
+
+        public Vector2 size;
+        public float Alpha
+        {
+            get => _alpha;
+            set
+            {
+                if (value == _alpha)
+                    return;
+
+                _alpha = value;
+
+                readyMark.alpha = value;
+                nameLabel.label.alpha = value;
+
+                if (kick != null)
+                {
+                    for (int i = 9; i < 17; i++)
+                        kick.roundedRect.sprites[i].alpha = Mathf.Lerp(0f, 1f, value);
+                    kick.menuLabel.label.alpha = value;
+                    kick.buttonBehav.greyedOut = value < ALPHA_THRESHOLD;
+                }
+
+                if (selectTeam != null)
+                {
+                    selectTeam.colorFill.a = value;
+                    selectTeam.colorEdge.a = value;
+                    DropDownEnabled = true;
+                }
+            }
+        }
+        public bool DropDownEnabled
+        {
+            get => selectTeam != null && !selectTeam.greyedOut;
+            set
+            {
+                bool greyedOut = !value || _alpha < ALPHA_THRESHOLD;
+                if (selectTeam == null || selectTeam.greyedOut == greyedOut)
+                    return;
+
+                // For some absurd reason, toggling selectTeam.greyedOut fires OnListClose.
+                // Below is the fix I came up with. If for some reason you need to change this, god help you.
+                if (greyedOut)
+                    selectTeam.OnListClose -= UnfocusDropDown;
+                else
+                    selectTeam.OnListClose += UnfocusDropDown;
+                selectTeam.greyedOut = greyedOut;
+            }
+        }
+        public PlayerData Data { get => data; }
+
+        public PlayerInfo(Menu.Menu menu, MenuObject owner, Vector2 pos, Vector2 size, bool controls, PlayerData data) : base(menu, owner, pos)
+        {
+            this.size = size;
+            this.data = data;
+
+            string nameAndTeam = $"{data.nickname} ({BingoPage.TeamName[data.team]})";
+
+            string markAtlas = data.isHost ? "TinyCrown" : data.ready ? "TinyCheck" : "TinyX";
+            Color markColor = data.isHost ? Color.yellow : data.ready ? Color.green : Color.red;
+            readyMark = new FSprite(markAtlas) { color = markColor };
+            Container.AddChild(readyMark);
+
+            nameLabel = new(menu, this, nameAndTeam, new Vector2(2f * MARGIN + READY_MARK_SIZE, size.y / 2f), Vector2.zero, false);
+            nameLabel.label.color = BingoPage.TEAM_COLOR[data.team];
+            nameLabel.label.alignment = FLabelAlignment.Left;
+            nameLabel.label.anchorY = 0.5f;
+            subObjects.Add(nameLabel);
+
+            if (!controls)
+                return;
+
+            Configurable<string> conf = MenuModList.ModButton.RainWorldDummy.config.Bind("_PlayerInfoSelect", BingoPage.TeamName[data.team], (ConfigAcceptableBase)null);
+            selectTeam = new(
+                    conf,
+                    new Vector2(size.x - MARGIN - SELECT_TEAM_WIDTH, DROPDOWN_SIZE), // DROPDOWN_SIZE part of hack described below
+                    SELECT_TEAM_WIDTH,
+                    ["Red", "Blue", "Green", "Orange", "Pink", "Cyan", "Black", "Hurricane", "Board view"]);
+            selectTeam.OnValueChanged += SelectTeam_OnValueChanged;
+            selectTeam.OnListOpen += FocusDropDown;
+            selectTeam.OnListClose += UnfocusDropDown;
+            // Hack to trick the ComboBox into thinking it has enough space to open downward.
+            // This is stupid. I hate this, but it's the cleanest workaround I found.
+            tabWrapper = new(menu, this) { pos = new Vector2(0f, -DROPDOWN_SIZE) };
+            subObjects.Add(tabWrapper);
+            selectTeamWrapper = new(tabWrapper, selectTeam);
+
+            if (!data.isSelf)
+            {
+                kick = new SimpleButton(
+                        menu,
+                        this,
+                        "Kick",
+                        $"KICK-{data.identity.GetSteamID64()}",
+                        new Vector2(size.x - 2f * MARGIN - SELECT_TEAM_WIDTH - KICK_WIDTH, 0f),
+                        new Vector2(KICK_WIDTH, size.y));
+                subObjects.Add(kick);
+            }
+        }
+
+        public override void GrafUpdate(float timeStacker)
+        {
+            if (kick != null)
+                kick.roundedRect.fillAlpha = Mathf.Lerp(0f, 0.3f, _alpha);
+
+            base.GrafUpdate(timeStacker);
+            
+            readyMark.SetPosition(DrawPos(timeStacker) + new Vector2(MARGIN, size.y / 2f));
+        }
+
+        public override void RemoveSprites()
+        {
+            base.RemoveSprites();
+            foreach (MenuObject obj in subObjects)
+            {
+                obj.RemoveSprites();
+                RecursiveRemoveSelectables(obj);
+            }
+            subObjects.Clear();
+            readyMark.RemoveFromContainer();
+        }
+
+        private void SelectTeam_OnValueChanged(UIconfig config, string value, string oldValue)
+        {
+            data.team = BingoPage.TeamNumber[value];
+            Singal(null, $"SWTEAM-{data.identity.GetSteamID64()}-{data.team}");
+        }
+
+        private void FocusDropDown(UIfocusable sender) => Singal(this, "FOCUS_DD");
+
+        private void UnfocusDropDown(UIfocusable sender) => Singal(this, "UNFOCUS_DD");
+    }
+}

--- a/BingoMode/BingoMenu/RandomizerPanel.cs
+++ b/BingoMode/BingoMenu/RandomizerPanel.cs
@@ -1,0 +1,210 @@
+﻿using BingoMode.BingoRandomizer;
+using Menu;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace BingoMode.BingoMenu
+{
+    internal class RandomizerPanel : PositionedMenuObject
+    {
+        private const float MARGIN = 10f;
+        private const float SYMBOL_BUTTON_SIZE = 24f; // not actually modifiable from here (though could be with a bit of work)
+        private const float DIVIDER_THICKNESS = 2f;
+        private const float HEADER_HEIGHT = 2f * MARGIN + SYMBOL_BUTTON_SIZE + DIVIDER_THICKNESS;
+        private const float LIST_BUTTON_HEIGHT = 20f;
+        private const float LIST_SPACING = 2f;
+        private const float SLIDER_WIDTH = 10f;
+        private const float SLIDER_OFFSET = 15f; // not actually modifiable from here
+        private const float SLIDER_DEAD_ZONE = 21f; // not actually modifiable from here
+
+        private bool _visible = true;
+        private MenuObject ownerMemory;
+        private MenuLabel randomizerLabel;
+        private FSprite divider;
+        private List<SimpleButton> randomizers = [];
+
+        public Vector2 size;
+        public float sliderF;
+        public bool Visible
+        {
+            get => _visible;
+            set
+            {
+                if (value == _visible)
+                    return;
+
+                if (value)
+                {
+                    owner = ownerMemory;
+                    PopulateRandomizerList();
+                }
+                else
+                {
+                    ClearRandomizerList();
+                    owner = null;
+                }
+                _visible = value;
+            }
+        }
+
+
+        public RandomizerPanel(Menu.Menu menu, MenuObject owner, Vector2 pos, Vector2 size) : base(menu, owner, pos)
+        {
+            ownerMemory = owner;
+            this.size = size;
+
+            RoundedRect background = new(menu, this, Vector2.zero, size, true);
+            subObjects.Add(background);
+
+            SymbolButton unloadButton = new(menu, this, "Menu_Symbol_Clear_All", "UNLOAD", new Vector2(MARGIN, size.y - SYMBOL_BUTTON_SIZE - MARGIN));
+            subObjects.Add(unloadButton);
+
+            randomizerLabel = new(menu, this, "unloaded", unloadButton.pos + new Vector2(SYMBOL_BUTTON_SIZE + MARGIN, 3f), new Vector2(0f, 18f), false);
+            randomizerLabel.label.alignment = FLabelAlignment.Left;
+            subObjects.Add(randomizerLabel);
+
+            divider = new("pixel")
+            {
+                scaleX = size.x,
+                scaleY = DIVIDER_THICKNESS,
+                anchorX = 0f,
+                anchorY = 0f,
+                x = pos.x,
+                y = pos.y + size.y - HEADER_HEIGHT
+            };
+            Container.AddChild(divider);
+
+            VerticalSlider slider = new(
+                    menu,
+                    this,
+                    "",
+                    new Vector2(size.x - MARGIN - SLIDER_OFFSET - SLIDER_WIDTH / 2f, MARGIN),
+                    new Vector2(SLIDER_WIDTH, size.y - HEADER_HEIGHT - 2 * MARGIN - SLIDER_DEAD_ZONE),
+                    BingoEnums.RandomizerSlider, true);
+            subObjects.Add(slider);
+            sliderF = 1f;
+        }
+
+        public override void GrafUpdate(float timeStacker)
+        {
+            base.GrafUpdate(timeStacker);
+
+            DrawProfileList(timeStacker);
+
+            divider.SetPosition(DrawPos(timeStacker) + new Vector2(0f, size.y - HEADER_HEIGHT));
+        }
+
+        public override void Singal(MenuObject sender, string message)
+        {
+            if (message.StartsWith("LOAD-"))
+            {
+                string profileName = message.Split('-')[1];
+                try
+                {
+                    BingoRandomizationProfile.LoadFromFile(profileName);
+                    randomizerLabel.text = profileName;
+                    BingoHooks.GlobalBoard.GenerateBoard(BingoHooks.GlobalBoard.size, false);
+                    menu.PlaySound(SoundID.MENU_Next_Slugcat);
+                }
+                catch (Exception e)
+                {
+                    Plugin.logger.LogError($"Error loading profile {profileName} : {e.Message}");
+                }
+                return;
+            }
+
+            if (message == "UNLOAD")
+            {
+                BingoRandomizationProfile.Unload();
+                randomizerLabel.text = "unloaded";
+                BingoHooks.GlobalBoard.GenerateBoard(BingoHooks.GlobalBoard.size, false);
+                menu.PlaySound(SoundID.MENU_Next_Slugcat);
+                return;
+            }
+
+            // TODO : add "refresh profiles" button sending this signal
+            if (message == "REFRESH")
+            {
+                ClearRandomizerList();
+                PopulateRandomizerList();
+                return;
+            }
+
+            // TODO : add "open folder" button sending this signal
+            if (message == "OPEN_FOLDER")
+            {
+                BingoRandomizationProfile.OpenSaveFolder();
+                return;
+            }
+
+            base.Singal(sender, message);
+        }
+
+        public override void RemoveSprites()
+        {
+            base.RemoveSprites();
+
+            owner = ownerMemory;
+            foreach (MenuObject obj in subObjects)
+            {
+                obj.RemoveSprites();
+                RecursiveRemoveSelectables(obj);
+            }
+            subObjects.Clear();
+            divider.RemoveFromContainer();
+        }
+
+        private void PopulateRandomizerList()
+        {
+            Vector2 position = new(MARGIN, size.y - HEADER_HEIGHT - MARGIN - LIST_BUTTON_HEIGHT);
+            Vector2 buttonSize = new(size.x - 3 * MARGIN - SLIDER_WIDTH, LIST_BUTTON_HEIGHT);
+            foreach (string profile in BingoRandomizationProfile.GetAvailableProfiles())
+            {
+                SimpleButton button = new(menu, this, profile, $"LOAD-{profile}", position, buttonSize);
+                randomizers.Add(button);
+                subObjects.Add(button);
+                position.y -= LIST_SPACING + LIST_BUTTON_HEIGHT;
+            }
+        }
+
+        private void ClearRandomizerList()
+        {
+            foreach (SimpleButton button in randomizers)
+            {
+                button.RemoveSprites();
+                RemoveSubObject(button);
+            }
+            randomizers.Clear();
+        }
+
+        private void DrawProfileList(float timeStacker)
+        {
+            float top = size.y - HEADER_HEIGHT - MARGIN - LIST_BUTTON_HEIGHT;
+            float bottom = MARGIN;
+            float list_height = (randomizers.Count - 1) * (LIST_BUTTON_HEIGHT + LIST_SPACING);
+            float y = top;
+            if (list_height > top - bottom)
+                y = Mathf.Lerp(list_height + bottom, top, sliderF);
+            foreach (SimpleButton button in randomizers)
+            {
+                float overshoot = (y > bottom + (top - bottom) / 2f) ?
+                        (y - top) / MARGIN :
+                        (bottom - y) / MARGIN;
+                SetButtonAlpha(button, 1f - overshoot);
+                button.buttonBehav.greyedOut = overshoot >= 1f;
+                button.pos.y = y;
+                y -= LIST_BUTTON_HEIGHT + LIST_SPACING;
+            }
+        }
+
+        private static void SetButtonAlpha(SimpleButton button, float alpha)
+        {
+            for (int i = 0; i < 9; i++)
+                button.roundedRect.sprites[i].alpha = Mathf.Lerp(0f, 0.3f, alpha);
+            for (int i = 9; i < 17; i++)
+                button.roundedRect.sprites[i].alpha = Mathf.Lerp(0f, 1f, alpha);
+            button.menuLabel.label.alpha = Mathf.Lerp(0f, 1f, alpha);
+        }
+    }
+}

--- a/BingoMode/BingoMode.csproj
+++ b/BingoMode/BingoMode.csproj
@@ -93,7 +93,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BingoBoard.cs" />
+    <Compile Include="BingoMenu\BoardControls.cs" />
     <Compile Include="BingoMenu\FilterDialog.cs" />
+    <Compile Include="BingoMenu\GameControls.cs" />
+    <Compile Include="BingoMenu\LobbyInfo.cs" />
+    <Compile Include="BingoMenu\MultiplayerPanel.cs" />
+    <Compile Include="BingoMenu\PlayerInfo.cs" />
+    <Compile Include="BingoMenu\RandomizerPanel.cs" />
     <Compile Include="BingoRandomizers\BingoRandomizationProfile.cs" />
     <Compile Include="BingoChallenges\BingoBroadcastChallenge.cs" />
     <Compile Include="BingoChallenges\BingoDodgeNootChallenge.cs" />

--- a/BingoMode/BingoSteamworks/InnerWorkings.cs
+++ b/BingoMode/BingoSteamworks/InnerWorkings.cs
@@ -17,11 +17,9 @@ namespace BingoMode.BingoSteamworks
     {
         public static void SendMessage(string data, SteamNetworkingIdentity receiver, bool reliable = true)
         {
-            if (receiver.GetSteamID() == SteamTest.selfIdentity.GetSteamID()) return;
+            if (receiver.GetSteamID() == SteamTest.selfIdentity.GetSteamID())
+                return;
             IntPtr ptr = Marshal.StringToHGlobalAuto(data);
-
-            //Plugin.logger.LogMessage("SENDING MESSAGE " + data);
-
             if (SteamNetworkingMessages.SendMessageToUser(ref receiver, ptr, (uint)(data.Length * sizeof(char)), reliable ? 40 : 32, 0) != EResult.k_EResultOK)
             {
                 Plugin.logger.LogError("FAILED TO SEND MESSAGE \"" + data + "\" TO USER " + receiver.GetSteamID());
@@ -128,10 +126,10 @@ namespace BingoMode.BingoSteamworks
                 case '@':
                     if (SteamTest.CurrentLobby == default) break;
 
-                    if (BingoData.globalMenu != null && BingoHooks.bingoPage.TryGetValue(BingoData.globalMenu, out var page6) && page6.inLobby)
+                    if (BingoData.globalMenu != null && BingoHooks.bingoPage.TryGetValue(BingoData.globalMenu, out var page6) && page6.InLobby)
                     {
-                        page6.multiButton.buttonBehav.greyedOut = false;
-                        page6.Singal(page6.multiButton, "LEAVE_LOBBY");
+                        page6.multiplayerButton.buttonBehav.greyedOut = false;
+                        page6.Singal(page6.multiplayerButton, "LEAVE_LOBBY");
                         Custom.rainWorld.processManager.ShowDialog(new InfoDialog(Custom.rainWorld.processManager, "You've been kicked from the lobby."));
                     }
                     break;

--- a/BingoMode/BingoSteamworks/SteamFinal.cs
+++ b/BingoMode/BingoSteamworks/SteamFinal.cs
@@ -230,10 +230,10 @@ namespace BingoMode.BingoSteamworks
         {
             int x = -1;
             int y = -1;
-            for (int i = 0; i < BingoHooks.GlobalBoard.challengeGrid.GetLength(0); i++)
+            for (int j = 0; j < BingoHooks.GlobalBoard.challengeGrid.GetLength(1); j++)
             {
                 bool b = false;
-                for (int j = 0; j < BingoHooks.GlobalBoard.challengeGrid.GetLength(1); j++)
+                for (int i = 0; i < BingoHooks.GlobalBoard.challengeGrid.GetLength(0); i++)
                 {
                     if (BingoHooks.GlobalBoard.challengeGrid[i, j] == ch)
                     {


### PR DESCRIPTION
* Fix crash when failing to generate challenge from profile. When failing, resort to default generation instead.

* Randomizer panel refactor. Moved to its own class
cleaned magic numbers
improved visuals
prepared logic for refresh and open folder buttons

* Multiplayer panel refactor. Lots of moving stuff around, lots of naming constants to kill magic numbers. A bit of removing useless code, a bit of simplifying other code. A marginal amount (too much) of bugfixing utter bullshit. WHERE ARE MY Z-INDEXES, JOHN? WHERE ARE THEY?

* Group bottom-right UI elements under GameControls. Also tiny fixes to multiplayer panel.

* Group top-left UI elements under BoardControls. Cleanup title and back button's magic numbers in bingo page.

* Transpose BingoBoard's data structure. Finally, goals are generated in lines rather than in columns. This changes practically nothing, but damn did it bother me.

* A few more fixes and cleanups.

* Hunt down some sneaky bingo board iteration outside of BingoBoard.cs. All of you must follow the holy order of iterating over `j` before `i`.

* Test your builds before pushing, kids. Otherwise you find yourself pushing a commit of shame that just adds one line.