### PR TITLE
Dotnet cli fix

### DIFF
--- a/BingoMode/BingoMode.csproj
+++ b/BingoMode/BingoMode.csproj
@@ -1,197 +1,36 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D641543B-A480-4D21-834E-80C4D766E437}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>BingoMode</RootNamespace>
     <AssemblyName>BingoMode</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <OutputPath>../mod/newest/plugins</OutputPath>
+    <PathMap>$(MSBuildProjectDirectory)=/$(SolutionName)</PathMap>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>preview</LangVersion>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>portable</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <LangVersion>preview</LangVersion>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DebugType>none</DebugType>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\lib\Assembly-CSharp-firstpass.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp-nstrip">
-      <HintPath>..\lib\Assembly-CSharp-nstrip.dll</HintPath>
-    </Reference>
-    <Reference Include="BepInEx">
-      <HintPath>..\lib\BepInEx.dll</HintPath>
-    </Reference>
-    <Reference Include="com.rlabrecque.steamworks.net">
-      <HintPath>..\lib\com.rlabrecque.steamworks.net.dll</HintPath>
-    </Reference>
-    <Reference Include="HOOKS-Assembly-CSharp">
-      <HintPath>..\lib\HOOKS-Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\lib\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="MonoMod">
-      <HintPath>..\lib\MonoMod.dll</HintPath>
-    </Reference>
-    <Reference Include="MonoMod.RuntimeDetour">
-      <HintPath>..\lib\MonoMod.RuntimeDetour.dll</HintPath>
-    </Reference>
-    <Reference Include="MonoMod.Utils">
-      <HintPath>..\lib\MonoMod.Utils.dll</HintPath>
-    </Reference>
-    <Reference Include="Rewired_Core">
-      <HintPath>..\lib\Rewired_Core.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="netstandard" />
-    <Reference Include="Unity.Mathematics">
-      <HintPath>..\lib\Unity.Mathematics.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>..\lib\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AudioModule">
-      <HintPath>..\lib\UnityEngine.AudioModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\lib\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>..\lib\UnityEngine.InputLegacyModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UnityWebRequestWWWModule">
-      <HintPath>..\lib\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+    <Reference Include="../lib/*.dll">
+      <Private>false</Private>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="BingoBoard.cs" />
-    <Compile Include="BingoMenu\BoardControls.cs" />
-    <Compile Include="BingoMenu\FilterDialog.cs" />
-    <Compile Include="BingoMenu\GameControls.cs" />
-    <Compile Include="BingoMenu\LobbyInfo.cs" />
-    <Compile Include="BingoMenu\MultiplayerPanel.cs" />
-    <Compile Include="BingoMenu\PlayerInfo.cs" />
-    <Compile Include="BingoMenu\RandomizerPanel.cs" />
-    <Compile Include="BingoRandomizers\BingoRandomizationProfile.cs" />
-    <Compile Include="BingoChallenges\BingoBroadcastChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoDodgeNootChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoDontKillChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoGourmandCrushChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoIteratorChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoLickChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoMoonCloakChallenge.cs" />
-    <Compile Include="BingoMenu\BingoCredits.cs" />
-    <Compile Include="BingoHUD\BingoHUDCheatButton.cs" />
-    <Compile Include="BingoMenu\BingoButton.cs" />
-    <Compile Include="BingoData.cs" />
-    <Compile Include="BingoEnums.cs" />
-    <Compile Include="BingoMenu\BingoGrid.cs" />
-    <Compile Include="BingoHUD\BingoHUDMain.cs" />
-    <Compile Include="BingoHooks.cs" />
-    <Compile Include="BingoHUD\BingoHUDButton.cs" />
-    <Compile Include="BingoHUD\BingoHUDCursor.cs" />
-    <Compile Include="BingoHUD\BingoHUDHint.cs" />
-    <Compile Include="BingoModOptions.cs" />
-    <Compile Include="BingoMenu\BingoPage.cs" />
-    <Compile Include="BingoRandomizers\BoolRandomizer.cs" />
-    <Compile Include="BingoRandomizers\ChallengeGroup.cs" />
-    <Compile Include="BingoRandomizers\ChallengeRandomizer.cs" />
-    <Compile Include="BingoRandomizers\GroupRandomizer.cs" />
-    <Compile Include="BingoRandomizers\Randomizer.cs" />
-    <Compile Include="BingoRandomizers\RangeRandomizer.cs" />
-    <Compile Include="BingoRandomizers\StringRandomizer.cs" />
-    <Compile Include="BingoRandomizers\Weighted.cs" />
-    <Compile Include="BingoRandomizers\WeightRandomizer.cs" />
-    <Compile Include="BingoSaveFile.cs" />
-    <Compile Include="BingoSong.cs" />
-    <Compile Include="BingoSteamworks\InnerWorkings.cs" />
-    <Compile Include="BingoSteamworks\LobbyFilters.cs" />
-    <Compile Include="BingoSteamworks\LobbySettings.cs" />
-    <Compile Include="BingoSteamworks\SteamFinal.cs" />
-    <Compile Include="BingoSteamworks\SteamTest.cs" />
-    <Compile Include="BingoChallenges\BingoAchievementChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoAllRegionsExceptChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoBombTollChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoCollectPearlChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoCraftChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoCreatureGateChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoCycleScoreChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoDepthsChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoDodgeLeviathanChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoEchoChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoEnterRegionFromChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoGlobalScoreChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoGreenNeuronChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoDamageChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoDontUseItemChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoEatChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoHatchNoodleChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoHellChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoItemHoardChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoKarmaFlowerChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoKillChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoMaulTypesChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoMaulXChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoNeuronDeliveryChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoNoNeedleTradingChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoEnterRegionChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoNoRegionChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoPearlDeliveryChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoPearlHoardChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoPinChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoPopcornChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoRivCellChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoSaintDeliveryChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoSaintPopcornChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoStealChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoTameChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoTradeChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoTradeTradedChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoTransportChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoUnlockChallenge.cs" />
-    <Compile Include="BingoChallenges\BingoVistaChallenge.cs" />
-    <Compile Include="BingoChallenges\ChallengeHooks.cs" />
-    <Compile Include="BingoChallenges\ChallengeUtils.cs" />
-    <Compile Include="BingoChallenges\ChallengeDisplay.cs" />
-    <Compile Include="BingoMenu\CreateLobbyDialog.cs" />
-    <Compile Include="BingoMenu\CustomizerDialog.cs" />
-    <Compile Include="BingoMenu\InfoDialog.cs" />
-    <Compile Include="Plugin.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SpectatorHooks.cs" />
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetPath)" "C:\Program Files (x86)\Steam\steamapps\common\Rain World\RainWorld_Data\StreamingAssets\mods\bingomode\plugins\$(TargetName).dll"</PostBuildEvent>
-  </PropertyGroup>
+    
+  <Target Name="GenerateMod" AfterTargets="PostBuildEvent" Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <ItemGroup>
+      <RemovePlugins Include="../mod/newest/plugins/*.pdb" />
+    </ItemGroup>
+
+    <Delete Files="@(RemovePlugins)" />
+  </Target>
+
 </Project>
+

--- a/BingoMode/BingoMode.csproj
+++ b/BingoMode/BingoMode.csproj
@@ -8,6 +8,7 @@
     <AssemblyName>BingoMode</AssemblyName>
     <OutputPath>../mod/newest/plugins</OutputPath>
     <PathMap>$(MSBuildProjectDirectory)=/$(SolutionName)</PathMap>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
uses the .csproj template from [alduris' template mod](https://github.com/alduris/TemplateMod) to make building the mod work with dotnet cli and cleans up csproj significantly

need testing on vs
as far as im aware, everyone uses vs, so no one would benefit from this? tho itd be really convenient for me to have this and not constantly have to stash n pop this